### PR TITLE
Bug-Fix: Do not apply filter if all deltas vanish, i.e., if Obs is zero

### DIFF
--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -975,7 +975,10 @@ def _filter_zeroes(names, deltas, idl, eps=Obs.filter_eps):
             new_names.append(name)
             new_deltas[name] = np.array(nd)
             new_idl[name] = ni
-    return (new_names, new_deltas, new_idl)
+    if new_names:
+        return (new_names, new_deltas, new_idl)
+    else:
+        return (new_names, new_deltas, new_idl)
 
 
 def derived_observable(func, data, **kwargs):

--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -978,7 +978,7 @@ def _filter_zeroes(names, deltas, idl, eps=Obs.filter_eps):
     if new_names:
         return (new_names, new_deltas, new_idl)
     else:
-        return (new_names, new_deltas, new_idl)
+        return (names, deltas, idl)
 
 
 def derived_observable(func, data, **kwargs):


### PR DESCRIPTION
Removing a bug that was present for vanishing obs and irregular chains.