### PR TITLE
Feature/irregular mc

### DIFF
--- a/pyerrors/linalg.py
+++ b/pyerrors/linalg.py
@@ -42,7 +42,7 @@ def derived_array(func, data, **kwargs):
     n_obs = len(raveled_data)
     new_names = sorted(set([y for x in [o.names for o in raveled_data] for y in x]))
 
-    is_merged = len(list(filter(lambda o: o.is_merged is True, raveled_data))) > 0
+    is_merged = {name: (len(list(filter(lambda o: o.is_merged.get(name, False) is True, raveled_data))) > 0) for name in new_names}
     reweighted = len(list(filter(lambda o: o.reweighted is True, raveled_data))) > 0
     new_idl_d = {}
     for name in new_names:
@@ -52,8 +52,8 @@ def derived_array(func, data, **kwargs):
             if tmp is not None:
                 idl.append(tmp)
         new_idl_d[name] = _merge_idx(idl)
-        if not is_merged:
-            is_merged = (1 != len(set([len(idx) for idx in [*idl, new_idl_d[name]]])))
+        if not is_merged[name]:
+            is_merged[name] = (1 != len(set([len(idx) for idx in [*idl, new_idl_d[name]]])))
 
     if data.ndim == 1:
         values = np.array([o.value for o in data])
@@ -100,17 +100,19 @@ def derived_array(func, data, **kwargs):
         new_samples = []
         new_means = []
         new_idl = []
-        if is_merged:
-            filtered_names, filtered_deltas, filtered_idl_d = _filter_zeroes(new_names, new_deltas, new_idl_d)
-        else:
-            filtered_names = new_names
-            filtered_deltas = new_deltas
-            filtered_idl_d = new_idl_d
-        for name in filtered_names:
+        filtered_deltas = {}
+        filtered_idl_d = {}
+        for name in new_names:
+            if is_merged[name]:
+                filtered_deltas[name], filtered_idl_d[name] = _filter_zeroes(new_deltas[name], new_idl_d[name])
+            else:
+                filtered_deltas[name] = new_deltas[name]
+                filtered_idl_d[name] = new_idl_d[name]
+        for name in new_names:
             new_samples.append(filtered_deltas[name])
             new_means.append(new_r_values[name][i_val])
             new_idl.append(filtered_idl_d[name])
-        final_result[i_val] = Obs(new_samples, filtered_names, means=new_means, idl=new_idl)
+        final_result[i_val] = Obs(new_samples, new_names, means=new_means, idl=new_idl)
         final_result[i_val]._value = new_val
         final_result[i_val].is_merged = is_merged
         final_result[i_val].reweighted = reweighted

--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -1017,9 +1017,7 @@ def derived_observable(func, data, **kwargs):
     n_obs = len(raveled_data)
     new_names = sorted(set([y for x in [o.names for o in raveled_data] for y in x]))
 
-    is_merged = {}
-    for name in list(set().union(*[o.names for o in raveled_data])):
-        is_merged[name] = len(list(filter(lambda o: o.is_merged.get(name, False) is True, raveled_data))) > 0
+    is_merged = {name: (len(list(filter(lambda o: o.is_merged.get(name, False) is True, raveled_data))) > 0) for name in new_names}
     reweighted = len(list(filter(lambda o: o.reweighted is True, raveled_data))) > 0
     new_idl_d = {}
     for name in new_names:
@@ -1095,21 +1093,19 @@ def derived_observable(func, data, **kwargs):
         new_samples = []
         new_means = []
         new_idl = []
-        filtered_names = []
         filtered_deltas = {}
         filtered_idl_d = {}
         for name in new_names:
-            filtered_names.append(name)
             if is_merged[name]:
                 filtered_deltas[name], filtered_idl_d[name] = _filter_zeroes(new_deltas[name], new_idl_d[name])
             else:
                 filtered_deltas[name] = new_deltas[name]
                 filtered_idl_d[name] = new_idl_d[name]
-        for name in filtered_names:
+        for name in new_names:
             new_samples.append(filtered_deltas[name])
             new_means.append(new_r_values[name][i_val])
             new_idl.append(filtered_idl_d[name])
-        final_result[i_val] = Obs(new_samples, filtered_names, means=new_means, idl=new_idl)
+        final_result[i_val] = Obs(new_samples, new_names, means=new_means, idl=new_idl)
         final_result[i_val]._value = new_val
         final_result[i_val].is_merged = is_merged
         final_result[i_val].reweighted = reweighted

--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -1101,18 +1101,16 @@ def derived_observable(func, data, **kwargs):
         new_samples = []
         new_means = []
         new_idl = []
-        filtered_deltas = {}
-        filtered_idl_d = {}
         for name in new_names:
             if is_merged[name]:
-                filtered_deltas[name], filtered_idl_d[name] = _filter_zeroes(new_deltas[name], new_idl_d[name])
+                filtered_deltas, filtered_idl_d = _filter_zeroes(new_deltas[name], new_idl_d[name])
             else:
-                filtered_deltas[name] = new_deltas[name]
-                filtered_idl_d[name] = new_idl_d[name]
-        for name in new_names:
-            new_samples.append(filtered_deltas[name])
+                filtered_deltas = new_deltas[name]
+                filtered_idl_d = new_idl_d[name]
+
+            new_samples.append(filtered_deltas)
+            new_idl.append(filtered_idl_d)
             new_means.append(new_r_values[name][i_val])
-            new_idl.append(filtered_idl_d[name])
         final_result[i_val] = Obs(new_samples, new_names, means=new_means, idl=new_idl)
         final_result[i_val]._value = new_val
         final_result[i_val].is_merged = is_merged


### PR DESCRIPTION
This change drastically reduces the time needed for derived_observables in the case of irregular MC chains that have been merged. 

_filter_zeroes has been very slow. This has been improved by two changes:
- instead of np.isclose, we now use a simple > (cf. https://github.com/numpy/numpy/issues/16160)
- Obs.is_merged is now a dict. Therefore, we only have to filter in ensembles, where a merged happened.

Before, the filter time was creating a huge overhead, that was prohibitively expensive. Now, the time is still non-negligible, but the delay is acceptable. One could think about abandoning the feature all together and only do the filtering if the user explicitly asks for it. This would speed everything up but in rare cases, the error estimate might be wrong.