### PR TITLE
Feature/json corr nd

### DIFF
--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -89,3 +89,36 @@ def test_json_string_reconstruction():
 
     assert reconstructed_string == json_string
     assert my_obs == reconstructed_obs2
+
+
+def test_json_corr_io():
+    my_list = [pe.Obs([np.random.normal(1.0, 0.1, 100)], ['ens1']) for o in range(8)]
+    rw_list = pe.reweight(pe.Obs([np.random.normal(1.0, 0.1, 100)], ['ens1']), my_list)
+
+    for obs_list in [my_list, rw_list]:
+        for tag in [None, "test"]:
+            obs_list[3].tag = tag
+            for fp in [0, 2]:
+                for bp in [0, 7]:
+                    for corr_tag in [None, 'my_Corr_tag']:
+                        my_corr = pe.Corr(obs_list, padding_front=fp, padding_back=bp)
+                        my_corr.tag = corr_tag
+                        pe.input.json.dump_to_json(my_corr, 'corr')
+                        recover = pe.input.json.load_json('corr')
+                        assert np.all([o.is_zero() for o in [x for x in (my_corr - recover) if x is not None]])
+                        assert my_corr.tag == recover.tag
+                        assert my_corr.reweighted == recover.reweighted
+
+
+def test_json_corr_2d_io():
+    obs_list = [np.array([[pe.pseudo_Obs(1.0 + i, 0.1 * i, 'test'), pe.pseudo_Obs(0.0, 0.1 * i, 'test')], [pe.pseudo_Obs(0.0, 0.1 * i, 'test'), pe.pseudo_Obs(1.0 + i, 0.1 * i, 'test')]]) for i in range(8)]
+
+    for tag in [None, "test"]:
+        obs_list[3][0, 1].tag = tag
+        for padding in [0, 1]:
+            my_corr = pe.Corr(obs_list, padding_front=padding, padding_back=padding)
+            my_corr.tag = tag
+            pe.input.json.dump_to_json(my_corr, 'corr')
+            recover = pe.input.json.load_json('corr')
+            assert np.all([np.all([o.is_zero() for o in q]) for q in [x.ravel() for x in (my_corr - recover) if x is not None]])
+            assert my_corr.tag == recover.tag

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -615,7 +615,7 @@ def test_covariance_symmetry():
     cov_ab = pe.covariance(test_obs1, a)
     cov_ba = pe.covariance(a, test_obs1)
     assert np.abs(cov_ab - cov_ba) <= 10 * np.finfo(np.float64).eps
-    assert np.abs(cov_ab) < test_obs1.dvalue * test_obs2.dvalue * (1 + 10 * np.finfo(np.float64).eps)
+    assert np.abs(cov_ab) < test_obs1.dvalue * a.dvalue * (1 + 10 * np.finfo(np.float64).eps)
 
 
 def test_empty_obs():


### PR DESCRIPTION
Here is a new version of the json import export for the correlator class based on three dimensional arrays. The implementation should work for one and multidimensional arrays. The additional metadata (padding and correlator tag) is saved in an additional entry to the list of tags. As separator for this metadata I used `|`.