### PR TITLE
Fix/effective mass padding

### DIFF
--- a/pyerrors/correlators.py
+++ b/pyerrors/correlators.py
@@ -42,9 +42,9 @@ class Corr:
         if not isinstance(data_input, list):
             raise TypeError('Corr__init__ expects a list of timeslices.')
 
-        if all([(isinstance(item, Obs) or isinstance(item, CObs)) for item in data_input]):
-            _assert_equal_properties(data_input)
-            self.content = [np.asarray([item]) for item in data_input]
+        if all([(isinstance(item, Obs) or isinstance(item, CObs)) or item is None for item in data_input]):
+            _assert_equal_properties([o for o in data_input if o is not None])
+            self.content = [np.asarray([item]) if item is not None else None for item in data_input]
             self.N = 1
 
         elif all([isinstance(item, np.ndarray) or item is None for item in data_input]) and any([isinstance(item, np.ndarray) for item in data_input]):

--- a/tests/correlators_test.py
+++ b/tests/correlators_test.py
@@ -51,23 +51,27 @@ def test_modify_correlator():
         corr.symmetric()
     with pytest.warns(RuntimeWarning):
         corr.anti_symmetric()
-    corr.roll(np.random.randint(100))
-    corr.deriv(symmetric=True)
-    corr.deriv(symmetric=False)
-    corr.deriv().deriv()
-    corr.second_deriv()
-    corr.second_deriv().second_deriv()
 
+    for pad in [0, 2]:
+        corr = pe.correlators.Corr(corr_content, padding=[pad, pad])
+        corr.roll(np.random.randint(100))
+        corr.deriv(symmetric=True)
+        corr.deriv(symmetric=False)
+        corr.deriv().deriv()
+        corr.second_deriv()
+        corr.second_deriv().second_deriv()
 
 
 def test_m_eff():
-    my_corr = pe.correlators.Corr([pe.pseudo_Obs(10, 0.1, 't'), pe.pseudo_Obs(9, 0.05, 't'), pe.pseudo_Obs(9, 0.1, 't'), pe.pseudo_Obs(10, 0.05, 't')])
-    my_corr.m_eff('log')
-    my_corr.m_eff('cosh')
-    my_corr.m_eff('arccosh')
+    for padding in [0, 4]:
+        my_corr = pe.correlators.Corr([pe.pseudo_Obs(10, 0.1, 't'), pe.pseudo_Obs(9, 0.05, 't'), pe.pseudo_Obs(9, 0.1, 't'), pe.pseudo_Obs(10, 0.05, 't')], padding=[padding, padding])
+        my_corr.m_eff('log')
+        my_corr.m_eff('cosh')
+        my_corr.m_eff('arccosh')
 
     with pytest.warns(RuntimeWarning):
         my_corr.m_eff('sinh')
+
 
 def test_reweighting():
     my_corr = pe.correlators.Corr([pe.pseudo_Obs(10, 0.1, 't'), pe.pseudo_Obs(0, 0.05, 't')])
@@ -133,7 +137,6 @@ def test_corr_exceptions():
     obs_b= pe.Obs([np.random.normal(0.1, 0.1, 100)], ['test2'])
     with pytest.raises(Exception):
         pe.Corr([obs_a, obs_b])
-
 
 
 def test_utility():


### PR DESCRIPTION
`None` values are now allowed when initializing 1D Corr objects. Fixes bug in Corr.m_eff
closes #43 