### PR TITLE
Bugfix in _reduce_deltas. Results were correct, but performance was bad

### DIFF
--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -1214,6 +1214,9 @@ def derived_observable(func, data, array_mode=False, **kwargs):
 def _reduce_deltas(deltas, idx_old, idx_new):
     """Extract deltas defined on idx_old on all configs of idx_new.
 
+    Assumes, that idx_old and idx_new are correctly defined idl, i.e., they
+    are ordered in an ascending order.
+
     Parameters
     ----------
     deltas : list
@@ -1233,8 +1236,6 @@ def _reduce_deltas(deltas, idx_old, idx_new):
     ret = np.zeros(shape)
     oldpos = 0
     for i in range(shape):
-        if oldpos == idx_old[i]:
-            raise Exception('idx_old and idx_new do not match!')
         pos = -1
         for j in range(oldpos, len(idx_old)):
             if idx_old[j] == idx_new[i]:
@@ -1242,7 +1243,8 @@ def _reduce_deltas(deltas, idx_old, idx_new):
                 break
         if pos < 0:
             raise Exception('Error in _reduce_deltas: Config %d not in idx_old' % (idx_new[i]))
-        ret[i] = deltas[j]
+        ret[i] = deltas[pos]
+        oldpos = pos
     return np.array(ret)
 
 

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -675,3 +675,19 @@ def test_import_jackknife():
     my_jacks = my_obs.export_jackknife()
     reconstructed_obs = pe.import_jackknife(my_jacks, 'test')
     assert my_obs == reconstructed_obs
+
+
+def test_reduce_deltas():
+    idx_old = range(1, 101)
+    deltas = [float(i) for i in idx_old]
+    idl = [
+        range(2, 26, 2),
+        range(1, 101),
+        np.arange(1, 101),
+        [1, 2, 3, 5, 6, 7, 9, 12],
+        [7],
+    ]
+    for idx_new in idl:
+        new = pe.obs._reduce_deltas(deltas, idx_old, idx_new)
+        print(new)
+        assert(np.alltrue([float(i) for i in idx_new] == new))


### PR DESCRIPTION
There was a stupid bug in _reduce_deltas, that involved a NxN double loop. The change leads to a speedup of N/2. Especially relevant for irregular MC chains or reweighting.,

Added tests to ensure correctness of the function.