### PR TITLE
fix: erroneous replica separator in json format caught and corrected

### DIFF
--- a/pyerrors/input/json.py
+++ b/pyerrors/input/json.py
@@ -307,10 +307,15 @@ def import_json_string(json_string, verbose=True, full_output=False):
             retd['is_merged'] = {}
             for ens in d:
                 for rep in ens['replica']:
-                    retd['names'].append(rep['name'])
+                    rep_name = rep['name']
+                    if len(rep_name) > len(ens["id"]):
+                        tmp_list = list(rep_name)
+                        tmp_list[len(ens["id"])] = "|"
+                        rep_name = ''.join(tmp_list)
+                    retd['names'].append(rep_name)
                     retd['idl'].append([di[0] for di in rep['deltas']])
                     retd['deltas'].append(np.array([di[1:] for di in rep['deltas']]))
-                    retd['is_merged'][rep['name']] = rep.get('is_merged', False)
+                    retd['is_merged'][rep_name] = rep.get('is_merged', False)
         return retd
 
     def _gen_covobsd_from_cdatad(d):

--- a/pyerrors/input/json.py
+++ b/pyerrors/input/json.py
@@ -309,9 +309,10 @@ def import_json_string(json_string, verbose=True, full_output=False):
                 for rep in ens['replica']:
                     rep_name = rep['name']
                     if len(rep_name) > len(ens["id"]):
-                        tmp_list = list(rep_name)
-                        tmp_list[len(ens["id"])] = "|"
-                        rep_name = ''.join(tmp_list)
+                        if rep_name[len(ens["id"])] != "|":
+                            tmp_list = list(rep_name)
+                            tmp_list = tmp_list[:len(ens["id"])] + ["|"] + tmp_list[len(ens["id"]):]
+                            rep_name = ''.join(tmp_list)
                     retd['names'].append(rep_name)
                     retd['idl'].append([di[0] for di in rep['deltas']])
                     retd['deltas'].append(np.array([di[1:] for di in rep['deltas']]))


### PR DESCRIPTION
With this little fix I am covering a very special case which should never happen with files written by pyerrors. This fix explicitly makes sure that the replica separator `|` is enforced in case another program wrote a json file with a different separator. This fix would imply that the separator `|` is not part of the format specification and would allow other implementations to use other separators.