### PR TITLE
Implicit calls to the gamma_method removed from methods of the Corr class

### DIFF
--- a/examples/02_correlators.ipynb
+++ b/examples/02_correlators.ipynb
@@ -68,7 +68,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "my_correlator = pe.Corr(correlator_data)"
+    "my_correlator = pe.Corr(correlator_data)\n",
+    "my_correlator.gamma_method()"
    ]
   },
   {

--- a/examples/04_fit_example.ipynb
+++ b/examples/04_fit_example.ipynb
@@ -46,7 +46,8 @@
     }
    ],
    "source": [
-    "fP = pe.Corr(pe.input.json.load_json(\"./data/f_P\"), padding=[1, 1])"
+    "fP = pe.Corr(pe.input.json.load_json(\"./data/f_P\"), padding=[1, 1])\n",
+    "fP.gamma_method()"
    ]
   },
   {
@@ -116,6 +117,7 @@
     "stop_fit = 18\n",
     "\n",
     "fit_result = fP.fit(func_exp, [start_fit, stop_fit], resplot=True)\n",
+    "fit_result.gamma_method()\n",
     "print(\"\\n\", fit_result)"
    ]
   },
@@ -197,6 +199,7 @@
     }
    ],
    "source": [
+    "m_eff_fP.gamma_method()\n",
     "m_eff_plateau = m_eff_fP.plateau([start_fit, stop_fit])\n",
     "m_eff_plateau.gamma_method()\n",
     "print()\n",
@@ -320,7 +323,7 @@
     }
    ],
    "source": [
-    "beta = pe.fits.odr_fit(ox, oy, func)\n",
+    "beta = pe.fits.total_least_squares(ox, oy, func)\n",
     "\n",
     "for i, item in enumerate(beta):\n",
     "    item.gamma_method()\n",

--- a/examples/06_gevp.ipynb
+++ b/examples/06_gevp.ipynb
@@ -130,7 +130,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "single_smearing = matrix_V1V1.index(0,0)"
+    "single_smearing = matrix_V1V1.item(0,0)"
    ]
   },
   {
@@ -284,7 +284,7 @@
     "m_eff_Jpsi = corr_ground.m_eff(variant=\"cosh\")\n",
     "\n",
     "# We can now pick a plateau range and get a single value for the mass. \n",
-    "\n",
+    "m_eff_Jpsi.gamma_method()\n",
     "m_Jpsi = m_eff_Jpsi.plateau([5, 24])\n",
     "\n",
     "# We can now visually compare our plateau value to the data\n",

--- a/pyerrors/correlators.py
+++ b/pyerrors/correlators.py
@@ -97,8 +97,6 @@ class Corr:
         self.T = len(self.content)
         self.prange = prange
 
-        self.gamma_method()
-
     def __getitem__(self, idx):
         """Return the content of timeslice idx"""
         if self.content[idx] is None:
@@ -138,8 +136,6 @@ class Corr:
         """
         if self.N == 1:
             raise Exception("Trying to project a Corr, that already has N=1.")
-
-        self.gamma_method()
 
         if vector_l is None:
             vector_l, vector_r = np.asarray([1.] + (self.N - 1) * [0.]), np.asarray([1.] + (self.N - 1) * [0.])
@@ -642,7 +638,6 @@ class Corr:
         xs = [x for x in range(fitrange[0], fitrange[1] + 1) if not self.content[x] is None]
         ys = [self.content[x][0] for x in range(fitrange[0], fitrange[1] + 1) if not self.content[x] is None]
         result = least_squares(xs, ys, function, silent=silent, **kwargs)
-        result.gamma_method()
         return result
 
     def plateau(self, plateau_range=None, method="fit"):
@@ -673,7 +668,6 @@ class Corr:
             return self.fit(const_func, plateau_range)[0]
         elif method in ["avg", "average", "mean"]:
             returnvalue = np.mean([item[0] for item in self.content[plateau_range[0]:plateau_range[1] + 1] if item is not None])
-            returnvalue.gamma_method()
             return returnvalue
 
         else:

--- a/tests/correlators_test.py
+++ b/tests/correlators_test.py
@@ -24,6 +24,7 @@ def test_function_overloading():
 
     for i, f in enumerate(fs):
         t1 = f([corr_a, corr_b])
+        t1.gamma_method()
         for o_a, o_b, con in zip(corr_content_a, corr_content_b, t1.content):
             t2 = f([o_a, o_b])
             t2.gamma_method()
@@ -175,6 +176,7 @@ def test_utility():
         corr_content.append(pe.pseudo_Obs(2 + 10 ** exponent, 10 ** (exponent - 1), 't'))
 
     corr = pe.correlators.Corr(corr_content)
+    corr.gamma_method()
     corr.print()
     corr.print([2, 4])
     corr.show()
@@ -183,6 +185,7 @@ def test_utility():
     corr.dump('test_dump', datatype="pickle", path='.')
     corr.dump('test_dump', datatype="pickle")
     new_corr = pe.load_object('test_dump.p')
+    new_corr.gamma_method()
     os.remove('test_dump.p')
     for o_a, o_b in zip(corr.content, new_corr.content):
         assert np.isclose(o_a[0].value, o_b[0].value)
@@ -192,6 +195,7 @@ def test_utility():
     corr.dump('test_dump', datatype="json.gz", path='.')
     corr.dump('test_dump', datatype="json.gz")
     new_corr = pe.input.json.load_json('test_dump')
+    new_corr.gamma_method()
     os.remove('test_dump.json.gz')
     for o_a, o_b in zip(corr.content, new_corr.content):
         assert np.isclose(o_a[0].value, o_b[0].value)
@@ -288,6 +292,7 @@ def test_thin():
     c = pe.Corr([pe.pseudo_Obs(i, .1, 'test') for i in range(10)])
     c *= pe.cov_Obs(1., .1, '#ren')
     thin = c.thin()
+    thin.gamma_method()
     thin.fit(lambda a, x: a[0] * x)
     c.thin(offset=1)
     c.thin(3, offset=1)


### PR DESCRIPTION
Calls to the gamma_method removed in Corr.__init__ and other methods of the Corr class.
Tests adjusted by adding additional calls to the `gamma_method`.

Closes #67 