### PR TITLE
bug fix: read methods are in fact closing files now

### DIFF
--- a/pyerrors/input/sfcf.py
+++ b/pyerrors/input/sfcf.py
@@ -248,7 +248,7 @@ def read_sfcf(path, prefix, name, quarks='.*', corr_type='bi', noffset=0, wf=0, 
                     else:
                         file.close()
                         raise Exception('Correlator with pattern\n' + pattern + '\nnot found.')
-                    
+
                 # we found where the correlator
                 # that is to be read is in the files
                 # after preparing the datastructure

--- a/pyerrors/input/sfcf.py
+++ b/pyerrors/input/sfcf.py
@@ -224,6 +224,7 @@ def read_sfcf(path, prefix, name, quarks='.*', corr_type='bi', noffset=0, wf=0, 
                             read = 1
                             start = k + 1
                     print(str(T) + " entries found.")
+                    file.close()
                 else:
                     pattern = 'name      ' + name + '\nquarks    ' + quarks + '\noffset    ' + str(noffset) + '\nwf        ' + str(wf)
                     if b2b:
@@ -243,8 +244,11 @@ def read_sfcf(path, prefix, name, quarks='.*', corr_type='bi', noffset=0, wf=0, 
                         T = content[match.start():].count('\n', 0, end_match.start()) - 4 - b2b
                         assert T > 0
                         print(T, 'entries, starting to read in line', start_read)
+                        file.close()
                     else:
+                        file.close()
                         raise Exception('Correlator with pattern\n' + pattern + '\nnot found.')
+                    
                 # we found where the correlator
                 # that is to be read is in the files
                 # after preparing the datastructure


### PR DESCRIPTION
Bug fixed that some files aren't closed in read method. Forgot to close the files that are used to look where the fitting correlator can be found in the files.