### PR TITLE
Reworked covariance

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -21,6 +21,6 @@ jobs:
       - name: flake8 Lint
         uses: py-actions/flake8@v1
         with:
-          ignore: "E501"
+          ignore: "E501,W605"
           exclude: "__init__.py, input/__init__.py"
           path: "pyerrors"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,12 +24,12 @@ For all pull requests tests are executed for the most recent python releases via
 ```
 pytest --cov=pyerrors -vv
 ```
-requiring `pytest`, `pytest-cov` and `pytest-benchmark`. To get a coverage report in html run 
+requiring `pytest`, `pytest-cov` and `pytest-benchmark`. To get a coverage report in html run
 ```
 pytest --cov=pyerrors --cov-report html
 ```
 The linter `flake8` is executed with the command
 ```
-flake8 --ignore=E501 --exclude=__init__.py pyerrors
+flake8 --ignore=E501,W605 --exclude=__init__.py pyerrors
 ```
 Please make sure that all tests are passed for a new pull requests.

--- a/pyerrors/fits.py
+++ b/pyerrors/fits.py
@@ -239,7 +239,7 @@ def total_least_squares(x, y, func, silent=False, **kwargs):
         if kwargs.get('covariance') is not None:
             cov = kwargs.get('covariance')
         else:
-            cov = covariance_matrix(np.concatenate((y, x.ravel())))
+            cov = covariance(np.concatenate((y, x.ravel())))
 
         number_of_x_parameters = int(m / x_f.shape[-1])
 
@@ -455,7 +455,7 @@ def _standard_fit(x, y, func, silent=False, **kwargs):
         x0 = [0.1] * n_parms
 
     if kwargs.get('correlated_fit') is True:
-        cov = covariance_matrix(y)
+        cov = covariance(y)
         covdiag = np.diag(1. / np.sqrt(np.diag(cov)))
         corr = np.copy(cov)
         for i in range(len(y)):
@@ -527,7 +527,7 @@ def _standard_fit(x, y, func, silent=False, **kwargs):
     if kwargs.get('expected_chisquare') is True:
         if kwargs.get('correlated_fit') is not True:
             W = np.diag(1 / np.asarray(dy_f))
-            cov = covariance_matrix(y)
+            cov = covariance(y)
             A = W @ jacobian(func)(fit_result.x, x)
             P_phi = A @ np.linalg.inv(A.T @ A) @ A.T
             expected_chisquare = np.trace((np.identity(x.shape[-1]) - P_phi) @ W @ cov @ W)
@@ -651,33 +651,9 @@ def residual_plot(x, y, func, fit_res):
     plt.draw()
 
 
-def covariance_matrix(y):
-    """Returns the covariance matrix of y.
-
-    Parameters
-    ----------
-    y : list or numpy.ndarray
-        List or one dimensional array of Obs
-    """
-    length = len(y)
-    cov = np.zeros((length, length))
-    for i, item in enumerate(y):
-        for j, jtem in enumerate(y[:i + 1]):
-            if i == j:
-                cov[i, j] = item.dvalue ** 2
-            else:
-                cov[i, j] = covariance(item, jtem)
-    cov = cov + cov.T - np.diag(np.diag(cov))
-    eigenvalues = np.linalg.eigh(cov)[0]
-    if not np.all(eigenvalues >= 0):
-        warnings.warn("Covariance matrix is not positive semi-definite", RuntimeWarning)
-        print("Eigenvalues of the covariance matrix:", eigenvalues)
-    return cov
-
-
 def error_band(x, func, beta):
     """Returns the error band for an array of sample values x, for given fit function func with optimized parameters beta."""
-    cov = covariance_matrix(beta)
+    cov = covariance(beta)
     if np.any(np.abs(cov - cov.T) > 1000 * np.finfo(np.float64).eps):
         warnings.warn("Covariance matrix is not symmetric within floating point precision", RuntimeWarning)
 

--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -1348,7 +1348,7 @@ def covariance(obs, visualize=False, correlation=False, **kwargs):
 
     Notes
     -----
-    The covariance is estimated by calculating the correlation matrix assuming no autocorrelation and then rescaling the correlation matrix by the full errors including the previous gamma method estimate for the autocorrelation of the observables. This is equivalent to assuming that the integrated autocorrelation time of an off-diagonal element is equal to the geometric mean of the integrated autocorrelation times of the corresponding diagonal elements.
+    The covariance is estimated by calculating the correlation matrix assuming no autocorrelation and then rescaling the correlation matrix by the full errors including the previous gamma method estimate for the autocorrelation of the observables. For observables defined on a single ensemble this is equivalent to assuming that the integrated autocorrelation time of an off-diagonal element is equal to the geometric mean of the integrated autocorrelation times of the corresponding diagonal elements.
     $$
     \tau_{\mathrm{int}, ij}=\sqrt{\tau_{\mathrm{int}, i}\times \tau_{\mathrm{int}, j}}
     $$
@@ -1384,7 +1384,7 @@ def covariance(obs, visualize=False, correlation=False, **kwargs):
 
 
 def _covariance_element(obs1, obs2):
-    """Estimates the uncorrelated covariance of two Obs objects."""
+    """Estimates the covariance of two Obs objects, neglecting autocorrelations."""
 
     def expand_deltas(deltas, idx, shape, new_idx):
         """Expand deltas defined on idx to a contiguous range [new_idx[0], new_idx[-1]].

--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -1332,7 +1332,7 @@ def correlate(obs_a, obs_b):
     return o
 
 
-def covariance(obs, visualize=False, **kwargs):
+def covariance(obs, visualize=False, correlation=False, **kwargs):
     """Calculates the covariance matrix of a set of observables.
 
     covariance([obs, obs])[0,1] is equal to obs.dvalue ** 2
@@ -1343,7 +1343,9 @@ def covariance(obs, visualize=False, **kwargs):
     obs : list or numpy.ndarray
         List or one dimensional array of Obs
     visualize : bool
-        Plots the corresponding normalized correlation matrix.
+        If True plots the corresponding normalized correlation matrix (default False).
+    correlation : bool
+        If True the correlation instead of the covariance is returned (default False).
     """
 
     length = len(obs)
@@ -1368,7 +1370,10 @@ def covariance(obs, visualize=False, **kwargs):
         plt.colorbar()
         plt.draw()
 
-    return cov
+    if correlation is True:
+        return corr
+    else:
+        return cov
 
 
 def _covariance_element(obs1, obs2):

--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -1335,7 +1335,6 @@ def correlate(obs_a, obs_b):
 def covariance(obs, visualize=False, correlation=False, **kwargs):
     """Calculates the covariance matrix of a set of observables.
 
-    covariance([obs, obs])[0,1] is equal to obs.dvalue ** 2
     The gamma method has to be applied first to all observables.
 
     Parameters
@@ -1346,6 +1345,14 @@ def covariance(obs, visualize=False, correlation=False, **kwargs):
         If True plots the corresponding normalized correlation matrix (default False).
     correlation : bool
         If True the correlation instead of the covariance is returned (default False).
+
+    Notes
+    -----
+    The covariance is estimated by calculating the correlation matrix assuming no autocorrelation and then rescaling the correlation matrix by the full errors including the previous gamma method estimate for the autocorrelation of the observables. This is equivalent to assuming that the integrated autocorrelation time of an off-diagonal element is equal to the geometric mean of the integrated autocorrelation times of the corresponding diagonal elements.
+    $$
+    \tau_{\mathrm{int}, ij}=\sqrt{\tau_{\mathrm{int}, i}\times \tau_{\mathrm{int}, j}}
+    $$
+    This construction ensures that the estimated covariance matrix is positive semi-definite (up to numerical rounding errors).
     """
 
     length = len(obs)

--- a/tests/covobs_test.py
+++ b/tests/covobs_test.py
@@ -39,8 +39,8 @@ def test_covobs():
         assert(np.isclose(oc.value, op.value, rtol=1e-14, atol=1e-14))
 
     [o.gamma_method() for o in cl]
-    assert(pe.covariance([cl[0], cl[1]])[0, 1] == cov[0][1])
-    assert(pe.covariance([cl[0], cl[1]])[0, 1] == cov[1][0])
+    assert(np.isclose(pe.covariance([cl[0], cl[1]])[0, 1], cov[0][1]))
+    assert(np.isclose(pe.covariance([cl[0], cl[1]])[0, 1], cov[1][0]))
 
     do = cl[0] * cl[1]
     assert(np.array_equal(do.covobs['rAP'].grad, np.transpose([pi[1], pi[0]]).reshape(2, 1)))
@@ -91,8 +91,8 @@ def test_covobs_covariance():
 
     covariance = pe.covariance(x)
 
-    assert covariance[0, 0] == covariance[1, 1]
-    assert covariance[0, 1] == a.dvalue ** 2 - b.dvalue ** 2
+    assert np.isclose(covariance[0, 0], covariance[1, 1])
+    assert np.isclose(covariance[0, 1], a.dvalue ** 2 - b.dvalue ** 2)
 
 
 def test_covobs_exceptions():

--- a/tests/covobs_test.py
+++ b/tests/covobs_test.py
@@ -39,8 +39,8 @@ def test_covobs():
         assert(np.isclose(oc.value, op.value, rtol=1e-14, atol=1e-14))
 
     [o.gamma_method() for o in cl]
-    assert(pe.covariance(cl[0], cl[1]) == cov[0][1])
-    assert(pe.covariance(cl[0], cl[1]) == cov[1][0])
+    assert(pe.covariance([cl[0], cl[1]])[0, 1] == cov[0][1])
+    assert(pe.covariance([cl[0], cl[1]])[0, 1] == cov[1][0])
 
     do = cl[0] * cl[1]
     assert(np.array_equal(do.covobs['rAP'].grad, np.transpose([pi[1], pi[0]]).reshape(2, 1)))
@@ -89,7 +89,7 @@ def test_covobs_covariance():
     x = [a + b, a - b]
     [o.gamma_method() for o in x]
 
-    covariance = pe.fits.covariance_matrix(x)
+    covariance = pe.covariance(x)
 
     assert covariance[0, 0] == covariance[1, 1]
     assert covariance[0, 1] == a.dvalue ** 2 - b.dvalue ** 2

--- a/tests/fits_test.py
+++ b/tests/fits_test.py
@@ -60,7 +60,7 @@ def test_least_squares():
         beta[i].gamma_method(S=1.0)
         assert math.isclose(beta[i].value, popt[i], abs_tol=1e-5)
         assert math.isclose(pcov[i, i], beta[i].dvalue ** 2, abs_tol=1e-3)
-    assert math.isclose(pe.covariance(beta[0], beta[1]), pcov[0, 1], abs_tol=1e-3)
+    assert math.isclose(pe.covariance([beta[0], beta[1]])[0, 1], pcov[0, 1], abs_tol=1e-3)
 
     chi2_pyerrors = np.sum(((f(x, *[o.value for o in beta]) - y) / yerr) ** 2) / (len(x) - 2)
     chi2_scipy = np.sum(((f(x, *popt) - y) / yerr) ** 2) / (len(x) - 2)
@@ -81,7 +81,7 @@ def test_least_squares():
         betac[i].gamma_method(S=1.0)
         assert math.isclose(betac[i].value, popt[i], abs_tol=1e-5)
         assert math.isclose(pcov[i, i], betac[i].dvalue ** 2, abs_tol=1e-3)
-    assert math.isclose(pe.covariance(betac[0], betac[1]), pcov[0, 1], abs_tol=1e-3)
+    assert math.isclose(pe.covariance([betac[0], betac[1]])[0, 1], pcov[0, 1], abs_tol=1e-3)
 
 
 def test_alternative_solvers():
@@ -195,7 +195,7 @@ def test_total_least_squares():
         beta[i].gamma_method(S=1.0)
         assert math.isclose(beta[i].value, output.beta[i], rel_tol=1e-5)
         assert math.isclose(output.cov_beta[i, i], beta[i].dvalue ** 2, rel_tol=2.5e-1), str(output.cov_beta[i, i]) + ' ' + str(beta[i].dvalue ** 2)
-    assert math.isclose(pe.covariance(beta[0], beta[1]), output.cov_beta[0, 1], rel_tol=2.5e-1)
+    assert math.isclose(pe.covariance([beta[0], beta[1]])[0, 1], output.cov_beta[0, 1], rel_tol=2.5e-1)
 
     out = pe.total_least_squares(ox, oy, func, const_par=[beta[1]])
 
@@ -218,7 +218,7 @@ def test_total_least_squares():
         betac[i].gamma_method(S=1.0)
         assert math.isclose(betac[i].value, output.beta[i], rel_tol=1e-3)
         assert math.isclose(output.cov_beta[i, i], betac[i].dvalue ** 2, rel_tol=2.5e-1), str(output.cov_beta[i, i]) + ' ' + str(betac[i].dvalue ** 2)
-    assert math.isclose(pe.covariance(betac[0], betac[1]), output.cov_beta[0, 1], rel_tol=2.5e-1)
+    assert math.isclose(pe.covariance([betac[0], betac[1]])[0, 1], output.cov_beta[0, 1], rel_tol=2.5e-1)
 
     outc = pe.total_least_squares(oxc, oyc, func, const_par=[betac[1]])
 
@@ -233,7 +233,7 @@ def test_total_least_squares():
         betac[i].gamma_method(S=1.0)
         assert math.isclose(betac[i].value, output.beta[i], rel_tol=1e-3)
         assert math.isclose(output.cov_beta[i, i], betac[i].dvalue ** 2, rel_tol=2.5e-1), str(output.cov_beta[i, i]) + ' ' + str(betac[i].dvalue ** 2)
-    assert math.isclose(pe.covariance(betac[0], betac[1]), output.cov_beta[0, 1], rel_tol=2.5e-1)
+    assert math.isclose(pe.covariance([betac[0], betac[1]])[0, 1], output.cov_beta[0, 1], rel_tol=2.5e-1)
 
     outc = pe.total_least_squares(oxc, oy, func, const_par=[betac[1]])
 

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -674,6 +674,23 @@ def test_covariance_factorizing():
     assert np.isclose(pe.covariance([mt0, tt[1]])[0, 1], -pe.covariance(tt)[0, 1])
 
 
+def test_covariance_alternation():
+    length = 12
+    t_fac = 2.5
+
+    tt1 = pe.misc.gen_correlated_data(np.zeros(length), -0.00001 * np.ones((length, length)) + 0.002 * np.diag(np.ones(length)), 'test', tau=0.5 + t_fac * np.random.rand(length), samples=88)
+    tt2 = pe.misc.gen_correlated_data(np.zeros(length), 0.9999 * np.ones((length, length)) + 0.0001 * np.diag(np.ones(length)), 'another_test|r0', tau=0.7 + t_fac * np.random.rand(length), samples=73)
+    tt3 = pe.misc.gen_correlated_data(np.zeros(length), 0.9999 * np.ones((length, length)) + 0.0001 * np.diag(np.ones(length)), 'another_test|r1', tau=0.7 + t_fac * np.random.rand(length), samples=91)
+
+    tt = np.array(tt1) + (np.array(tt2) + np.array(tt3))
+    tt *= np.resize([1, -1], length)
+
+    [o.gamma_method() for o in tt]
+    cov = pe.covariance(tt, True)
+
+    assert np.all(np.linalg.eigh(cov)[0] > -1e-15)
+
+
 def test_covariance_correlation():
     test_obs = pe.pseudo_Obs(-4, 0.8, 'test', samples=784)
     assert np.allclose(pe.covariance([test_obs, test_obs, test_obs], correlation=True), np.ones((3, 3)))

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -251,10 +251,10 @@ def test_covariance_is_variance():
     dvalue = np.abs(np.random.normal(0, 1))
     test_obs = pe.pseudo_Obs(value, dvalue, 't')
     test_obs.gamma_method()
-    assert np.abs(test_obs.dvalue ** 2 - pe.covariance(test_obs, test_obs)) <= 10 * np.finfo(np.float64).eps
+    assert np.abs(test_obs.dvalue ** 2 - pe.covariance([test_obs, test_obs])[0, 1]) <= 10 * np.finfo(np.float64).eps
     test_obs = test_obs + pe.pseudo_Obs(value, dvalue, 'q', 200)
     test_obs.gamma_method()
-    assert np.abs(test_obs.dvalue ** 2 - pe.covariance(test_obs, test_obs)) <= 10 * np.finfo(np.float64).eps
+    assert np.abs(test_obs.dvalue ** 2 - pe.covariance([test_obs, test_obs])[0, 1]) <= 10 * np.finfo(np.float64).eps
 
 
 def test_fft():
@@ -266,21 +266,6 @@ def test_fft():
     test_obs2.gamma_method(fft=False)
     assert max(np.abs(test_obs1.e_rho['t'] - test_obs2.e_rho['t'])) <= 10 * np.finfo(np.float64).eps
     assert np.abs(test_obs1.dvalue - test_obs2.dvalue) <= 10 * max(test_obs1.dvalue, test_obs2.dvalue) * np.finfo(np.float64).eps
-
-
-def test_covariance_symmetry():
-    value1 = np.random.normal(5, 10)
-    dvalue1 = np.abs(np.random.normal(0, 1))
-    test_obs1 = pe.pseudo_Obs(value1, dvalue1, 't')
-    test_obs1.gamma_method()
-    value2 = np.random.normal(5, 10)
-    dvalue2 = np.abs(np.random.normal(0, 1))
-    test_obs2 = pe.pseudo_Obs(value2, dvalue2, 't')
-    test_obs2.gamma_method()
-    cov_ab = pe.covariance(test_obs1, test_obs2)
-    cov_ba = pe.covariance(test_obs2, test_obs1)
-    assert np.abs(cov_ab - cov_ba) <= 10 * np.finfo(np.float64).eps
-    assert np.abs(cov_ab) < test_obs1.dvalue * test_obs2.dvalue * (1 + 10 * np.finfo(np.float64).eps)
 
 
 def test_gamma_method_uncorrelated():
@@ -629,8 +614,8 @@ def test_covariance_symmetry():
     dvalue2 = np.abs(np.random.normal(0, 1))
     test_obs2 = pe.pseudo_Obs(value2, dvalue2, 't')
     test_obs2.gamma_method()
-    cov_ab = pe.covariance(test_obs1, test_obs2)
-    cov_ba = pe.covariance(test_obs2, test_obs1)
+    cov_ab = pe.covariance([test_obs1, test_obs2])[0, 1]
+    cov_ba = pe.covariance([test_obs2, test_obs1])[0, 1]
     assert np.abs(cov_ab - cov_ba) <= 10 * np.finfo(np.float64).eps
     assert np.abs(cov_ab) < test_obs1.dvalue * test_obs2.dvalue * (1 + 10 * np.finfo(np.float64).eps)
 
@@ -643,10 +628,10 @@ def test_covariance_symmetry():
     idx = [i + 1 for i in range(len(configs)) if configs[i] == 1]
     a = pe.Obs([zero_arr], ['t'], idl=[idx])
     a.gamma_method()
-    assert np.isclose(a.dvalue**2, pe.covariance(a, a), atol=100, rtol=1e-4)
+    assert np.isclose(a.dvalue ** 2, pe.covariance([a, a])[0, 1], atol=100, rtol=1e-4)
 
-    cov_ab = pe.covariance(test_obs1, a)
-    cov_ba = pe.covariance(a, test_obs1)
+    cov_ab = pe.covariance([test_obs1, a])[0, 1]
+    cov_ba = pe.covariance([a, test_obs1])[0, 1]
     assert np.abs(cov_ab - cov_ba) <= 10 * np.finfo(np.float64).eps
     assert np.abs(cov_ab) < test_obs1.dvalue * a.dvalue * (1 + 10 * np.finfo(np.float64).eps)
 


### PR DESCRIPTION
I removed the `fits.covariance_matrix` function and adjusted `covariance` to operate on a list of observables and return a matrix.
I also reworked the way the covariance is estimated and I believe that the new estimator ensures positive semi-definiteness of the covariance matrix up to machine precision. The `covariance` function now also allows for a direct visualization of the corresponding (normalized) correlation matrix. I also added additional tests for the covariance.