### PR TITLE
Fix/covariance idl

### DIFF
--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -996,7 +996,7 @@ def _intersection_idx(idl):
             idstep = max([idx.step for idx in idl])
             return range(idstart, idstop, idstep)
 
-    return sorted(set().intersection(*idl))
+    return sorted(set.intersection(*[set(o) for o in tt]))
 
 
 def _expand_deltas_for_merge(deltas, idx, shape, new_idx):

--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -974,7 +974,7 @@ def _merge_idx(idl):
 
 def _expand_deltas_for_merge(deltas, idx, shape, new_idx):
     """Expand deltas defined on idx to the list of configs that is defined by new_idx.
-       New, empy entries are filled by 0. If idx and new_idx are of type range, the smallest
+       New, empty entries are filled by 0. If idx and new_idx are of type range, the smallest
        common divisor of the step sizes is used as new step size.
 
     Parameters
@@ -1416,31 +1416,9 @@ def _smooth_eigenvalues(corr, E):
 def _covariance_element(obs1, obs2):
     """Estimates the covariance of two Obs objects, neglecting autocorrelations."""
 
-    def expand_deltas(deltas, idx, shape, new_idx):
-        """Expand deltas defined on idx to a contiguous range [new_idx[0], new_idx[-1]].
-           New, empy entries are filled by 0. If idx and new_idx are of type range, the smallest
-           common divisor of the step sizes is used as new step size.
-
-        Parameters
-        ----------
-        deltas  -- List of fluctuations
-        idx     -- List or range of configs on which the deltas are defined.
-                   Has to be a subset of new_idx.
-        shape   -- Number of configs in idx.
-        new_idx -- List of configs that defines the new range.
-        """
-
-        if type(idx) is range and type(new_idx) is range:
-            if idx == new_idx:
-                return deltas
-        ret = np.zeros(new_idx[-1] - new_idx[0] + 1)
-        for i in range(shape):
-            ret[idx[i] - new_idx[0]] = deltas[i]
-        return ret
-
     def calc_gamma(deltas1, deltas2, idx1, idx2, new_idx):
-        deltas1 = expand_deltas(deltas1, idx1, len(idx1), new_idx)
-        deltas2 = expand_deltas(deltas2, idx2, len(idx2), new_idx)
+        deltas1 = _expand_deltas_for_merge(deltas1, idx1, len(idx1), new_idx)
+        deltas2 = _expand_deltas_for_merge(deltas2, idx2, len(idx2), new_idx)
         return np.sum(deltas1 * deltas2)
 
     if set(obs1.names).isdisjoint(set(obs2.names)):

--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -1,5 +1,7 @@
 import warnings
 import pickle
+from math import gcd
+from functools import reduce
 import numpy as np
 import autograd.numpy as anp  # Thinly-wrapped numpy
 from autograd import jacobian
@@ -981,6 +983,12 @@ def _intersection_idx(idl):
         List of lists or ranges.
     """
 
+    def _lcm(*args):
+        """Returns the lowest common multiple of args.
+
+        From python 3.9 onwards the math library contains an lcm function."""
+        return reduce(lambda a, b: a * b // gcd(a, b), args)
+
     # Use groupby to efficiently check whether all elements of idl are identical
     try:
         g = groupby(idl)
@@ -993,10 +1001,10 @@ def _intersection_idx(idl):
         if len(set([idx[0] for idx in idl])) == 1:
             idstart = max([idx.start for idx in idl])
             idstop = min([idx.stop for idx in idl])
-            idstep = max([idx.step for idx in idl])
+            idstep = _lcm(*[idx.step for idx in idl])
             return range(idstart, idstop, idstep)
 
-    return sorted(set.intersection(*[set(o) for o in tt]))
+    return sorted(set.intersection(*[set(o) for o in idl]))
 
 
 def _expand_deltas_for_merge(deltas, idx, shape, new_idx):

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -515,6 +515,26 @@ def test_merge_idx():
     assert pe.obs._merge_idx([range(500, 6050, 50), range(500, 6250, 250)]) == range(500, 6250, 50)
 
 
+def test_intersection_idx():
+    assert pe.obs._intersection_idx([range(1, 100), range(1, 100), range(1, 100)]) == range(1, 100)
+    assert pe.obs._intersection_idx([range(1, 100, 10), range(1, 100, 2)]) == range(1, 100, 10)
+    assert pe.obs._intersection_idx([range(10, 1010, 10), range(10, 1010, 50)]) == range(10, 1010, 50)
+    assert pe.obs._intersection_idx([range(500, 6050, 50), range(500, 6250, 250)]) == range(500, 6050, 250)
+
+
+def test_intersection_collapse():
+    range1 = range(1, 2000, 2)
+    range2 = range(2, 2001, 8)
+
+    obs1 = pe.Obs([np.random.normal(1.0, 0.1, len(range1))], ["ens"], idl=[range1])
+    obs_merge = obs1 + pe.Obs([np.random.normal(1.0, 0.1, len(range2))], ["ens"], idl=[range2])
+
+    intersection = pe.obs._intersection_idx([o.idl["ens"] for o in [obs1, obs_merge]])
+    coll = pe.obs._collapse_deltas_for_merge(obs_merge.deltas["ens"], obs_merge.idl["ens"], len(obs_merge.idl["ens"]), range1)
+
+    assert np.all(coll == obs1.deltas["ens"])
+
+
 def test_irregular_error_propagation():
     obs_list = [pe.Obs([np.random.rand(100)], ['t']),
                 pe.Obs([np.random.rand(50)], ['t'], idl=[range(1, 100, 2)]),

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -521,6 +521,9 @@ def test_intersection_idx():
     assert pe.obs._intersection_idx([range(10, 1010, 10), range(10, 1010, 50)]) == range(10, 1010, 50)
     assert pe.obs._intersection_idx([range(500, 6050, 50), range(500, 6250, 250)]) == range(500, 6050, 250)
 
+    for ids in [[list(range(1, 80, 3)), list(range(1, 100, 2))], [range(1, 80, 3), range(1, 100, 2), range(1, 100, 7)]]:
+        assert list(pe.obs._intersection_idx(ids)) == pe.obs._intersection_idx([list(o) for o in ids])
+
 
 def test_intersection_collapse():
     range1 = range(1, 2000, 2)

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -749,6 +749,32 @@ def test_covariance_idl():
     pe.covariance([obs1, obs2])
 
 
+def test_correlation_intersection_of_idls():
+    range1 = range(1, 2000, 2)
+    range2 = range(2, 2001, 2)
+
+    obs1 = pe.Obs([np.random.normal(1.0, 0.1, len(range1))], ["ens"], idl=[range1])
+    obs2_a = 0.4 * pe.Obs([np.random.normal(1.0, 0.1, len(range1))], ["ens"], idl=[range1]) + 0.6 * obs1
+    obs1.gamma_method()
+    obs2_a.gamma_method()
+
+    cov1 = pe.covariance([obs1, obs2_a])
+    corr1 = pe.covariance([obs1, obs2_a], correlation=True)
+
+    obs2_b = obs2_a + pe.Obs([np.random.normal(1.0, 0.1, len(range2))], ["ens"], idl=[range2])
+    obs2_b.gamma_method()
+
+    cov2 = pe.covariance([obs1, obs2_b])
+    corr2 = pe.covariance([obs1, obs2_b], correlation=True)
+
+    assert np.isclose(corr1[0, 1], corr2[0, 1], atol=1e-14)
+    assert cov1[0, 1] > cov2[0, 1]
+
+    obs2_c = pe.Obs([np.random.normal(1.0, 0.1, len(range2))], ["ens"], idl=[range2])
+    obs2_c.gamma_method()
+    assert np.isclose(0, pe.covariance([obs1, obs2_c])[0, 1], atol=1e-14)
+
+
 def test_empty_obs():
     o = pe.Obs([np.random.rand(100)], ['test'])
     q = o + pe.Obs([], [], means=[])


### PR DESCRIPTION
I fixed a bug in `covariance` which occurred for some combinations of idls (see the new `test_covariance_idl`). I think the fix is just to replace `expand_deltas` within `covariance` by `obs._expand_deltas_for_merge`. The difference between the two is only that the latter collapses the expanded data back into the provided idl. Can you take a closer look at this @s-kuberski ?