### PR TITLE
Implemented the pruning of large correlation matrices by the solution…

### DIFF
--- a/tests/correlators_test.py
+++ b/tests/correlators_test.py
@@ -342,3 +342,21 @@ def _gen_corr(val, samples=2000):
 
     return pe.correlators.Corr(corr_content)
 
+
+def test_prune():
+
+    corr_aa = _gen_corr(1)
+    corr_ab = 0.5 * corr_aa
+    corr_ac = 0.25 * corr_aa
+
+    corr_mat = pe.Corr(np.array([[corr_aa, corr_ab, corr_ac], [corr_ab, corr_aa, corr_ab], [corr_ac, corr_ab, corr_aa]]))
+
+    p = corr_mat.prune(2)
+    assert(all([o.is_zero() for o in p.item(0, 1)]))
+    a = [(o - 1) for o in p.item(1, 1)]
+    [o.gamma_method() for o in a]
+    assert(all([o.is_zero_within_error() for o in a]))
+
+    with pytest.raises(Exception):
+        corr_mat.prune(3)
+        corr_mat.prune(4)


### PR DESCRIPTION
… of a GEVP at early times

This may help to allow for a solution of the GEVP at late time slices based on a large operator basis. At the same time, the correctness of the GEVP is not in question.

Unfortunately, the method GEVP does not allow to return all eigenvectors at the same time such that an unnecessary number of inversions has to be performed. This could be improved by changing ```GEVP``` (the docstring of that method is not totally instructive) and adapting ```prune``` afterwards.