### PR TITLE
Use rapidjson instead of json for I/O

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setup(name='pyerrors',
       author_email='fabian.joswig@ed.ac.uk',
       packages=find_packages(),
       python_requires='>=3.6.0',
-      install_requires=['numpy>=1.16', 'autograd>=1.4', 'numdifftools', 'matplotlib>=3.3', 'scipy', 'iminuit>=2', 'h5py', 'lxml']
+      install_requires=['numpy>=1.16', 'autograd>=1.4', 'numdifftools', 'matplotlib>=3.3', 'scipy', 'iminuit>=2', 'h5py', 'lxml', 'python-rapidjson']
      )


### PR DESCRIPTION
This change from json to rapidjson helps to achieve an order of magnitude of speedup when writing large JSON files to disk. At the same time, the memory footprint is smaller. The option ```write_mode=json.WM_SINGLE_LINE_ARRAY``` allows to get rid of the ugly workaround for having a human readable format, if indent!=0. 

This would add the dependence on ```python-rapidjson``` (I have not added this to the ```setup.py```, because I like to discuss it first). We could insert something like 
```python
try:
    import rapidjson as json
except ImportError:
    import json
```
to allow the user to do the export using the ```json``` module and to improve performance by installing ```rapidjson```. This would need some small adjustments in ```create_json_string``` to handle both cases appropriately.