### PR TITLE
GEVP rehaul 2

### DIFF
--- a/examples/06_gevp.ipynb
+++ b/examples/06_gevp.ipynb
@@ -168,9 +168,9 @@
     }
    ],
    "source": [
-    "vec = matrix_V1V1.GEVP(t0=3, ts=6 ,state=0, sorted_list=None)\n",
-    "assert len(vec) == matrix_V1V1.N\n",
-    "print(vec)"
+    "vecs = matrix_V1V1.GEVP(t0=3, ts=6, sort=None)\n",
+    "assert len(vecs[0]) == matrix_V1V1.N\n",
+    "print(vecs[0])"
    ]
   },
   {
@@ -202,7 +202,7 @@
     }
    ],
    "source": [
-    "matrix_V1V1.projected(vec).m_eff().show(comp=single_smearing.m_eff(), auto_gamma=True)"
+    "matrix_V1V1.projected(vecs[0]).m_eff().show(comp=single_smearing.m_eff(), auto_gamma=True)"
    ]
   },
   {
@@ -266,7 +266,7 @@
     "\n",
     "# We then solve the GEVP to get eigenvectors corresponding to the ground state.\n",
     "\n",
-    "vec_ground = matrix_VnVn.GEVP(t0=3, ts=6, state=0, sorted_list=None)\n",
+    "vec_ground = matrix_VnVn.GEVP(t0=3, ts=6, sort=None)[0]\n",
     "\n",
     "# Now we project the matrix-correlators to get new correlators belonging to the ground state.\n",
     "\n",

--- a/pyerrors/correlators.py
+++ b/pyerrors/correlators.py
@@ -245,7 +245,11 @@ class Corr:
         r'''Solve the generalized eigenvalue problem on the correlator matrix and returns the corresponding eigenvectors.
 
         The eigenvectors are sorted according to the descending eigenvalues, the zeroth eigenvector(s) correspond to the
-        largest eigenvalue(s).
+        largest eigenvalue(s). The eigenvector(s) for the individual states can be accessed via slicing
+        ```python
+        C.GEVP(t0=2)[0]  # Ground state vector(s)
+        C.GEVP(t0=2)[:3]  # Vectors for the lowest three states
+        ```
 
         Parameters
         ----------
@@ -259,6 +263,11 @@ class Corr:
             - "Eigenvalue": The eigenvector is chosen according to which eigenvalue it belongs individually on every timeslice.
             - "Eigenvector": Use the method described in arXiv:2004.10472 to find the set of v(t) belonging to the state.
               The reference state is identified by its eigenvalue at $t=t_s$.
+
+        Other Parameters
+        ----------------
+        state : int
+           Returns only the vector(s) for a specified state. The lowest state is zero.
         '''
 
         if self.N == 1:
@@ -310,7 +319,6 @@ class Corr:
             raise Exception("Unkown value for 'sort'.")
 
         if "state" in kwargs:
-            warnings.warn("Argument 'state' is deprecated, use slicing instead.", DeprecationWarning)
             return reordered_vecs[kwargs.get("state")]
         else:
             return reordered_vecs

--- a/pyerrors/correlators.py
+++ b/pyerrors/correlators.py
@@ -1219,8 +1219,6 @@ def _sort_vectors(vec_set, ts):
     return sorted_vec_set
 
 
-def _GEVP_solver(Gt, G0):  # Just so normalization an sorting does not need to be repeated. Here we could later put in some checks
-    sp_val, sp_vecs = scipy.linalg.eigh(Gt, G0)
-    sp_vecs = [sp_vecs[:, np.argsort(sp_val)[-i]] for i in range(1, sp_vecs.shape[0] + 1)]
-    sp_vecs = [v / np.sqrt((v.T @ G0 @ v)) for v in sp_vecs]
-    return sp_vecs
+def _GEVP_solver(Gt, G0):
+    """Helper function for solving the GEVP and sorting the eigenvectors."""
+    return scipy.linalg.eigh(Gt, G0)[1].T[::-1]

--- a/pyerrors/correlators.py
+++ b/pyerrors/correlators.py
@@ -241,7 +241,7 @@ class Corr:
         if self.N == 1:
             raise Exception("Trying to symmetrize a correlator matrix, that already has N=1.")
 
-    def GEVP(self, t0, ts=None, sort="Eigenvalue"):
+    def GEVP(self, t0, ts=None, sort="Eigenvalue", **kwargs):
         """Solve the generalized eigenvalue problem on the current correlator and returns the corresponding eigenvectors.
 
         Parameters
@@ -260,6 +260,10 @@ class Corr:
 
         if self.N == 1:
             raise Exception("GEVP methods only works on correlator matrices and not single correlators.")
+
+        if "sorted_list" in kwargs:
+            sort = kwargs.get("sorted_list")
+            warnings.warn("Argument 'sorted_list' is deprecated, use 'sort' instead.", DeprecationWarning)
 
         symmetric_corr = self.matrix_symmetric()
         if sort is None:

--- a/pyerrors/correlators.py
+++ b/pyerrors/correlators.py
@@ -263,6 +263,9 @@ class Corr:
 
         if self.N == 1:
             raise Exception("GEVP methods only works on correlator matrices and not single correlators.")
+        if ts is not None:
+            if (ts <= t0):
+                raise Exception("ts has to be larger than t0.")
 
         if "sorted_list" in kwargs:
             warnings.warn("Argument 'sorted_list' is deprecated, use 'sort' instead.", DeprecationWarning)
@@ -272,8 +275,6 @@ class Corr:
         if sort is None:
             if (ts is None):
                 raise Exception("ts is required if sort=None.")
-            if (ts <= t0):
-                raise Exception("ts has to be larger than t0.")
             if (self.content[t0] is None) or (self.content[ts] is None):
                 raise Exception("Corr not defined at t0/ts.")
             G0, Gt = np.empty([self.N, self.N], dtype="double"), np.empty([self.N, self.N], dtype="double")

--- a/pyerrors/correlators.py
+++ b/pyerrors/correlators.py
@@ -276,8 +276,8 @@ class Corr:
                     Gt[i, j] = symmetric_corr[ts][i, j].value
 
             sp_vecs = _GEVP_solver(Gt, G0)
-            sp_vec = [sp_vecs[s] for s in range(self.N)]
-            return sp_vec
+            return sp_vecs
+
         elif sort in ["Eigenvalue", "Eigenvector"]:
             if sort == "Eigenvalue" and ts is not None:
                 warnings.warn("ts has no effect when sorting by eigenvalue is chosen.", RuntimeWarning)
@@ -290,23 +290,17 @@ class Corr:
                             G0[i, j] = symmetric_corr[t0][i, j].value
                             Gt[i, j] = symmetric_corr[t][i, j].value
 
-                    sp_vecs = _GEVP_solver(Gt, G0)
-                    if sort == "Eigenvalue":
-                        sp_vec = [sp_vecs[s] for s in range(self.N)]
-                        all_vecs.append(sp_vec)
-                    else:
-                        all_vecs.append(sp_vecs)
+                    all_vecs.append(_GEVP_solver(Gt, G0))
                 except Exception:
                     all_vecs.append(None)
             if sort == "Eigenvector":
                 if (ts is None):
                     raise Exception("ts is required for the Eigenvector sorting method.")
                 all_vecs = _sort_vectors(all_vecs, ts)
-                all_vecs = [[a[s] if a is not None else None for a in all_vecs] for s in range(self.N)]
         else:
             raise Exception("Unkown value for 'sort'.")
 
-        return all_vecs
+        return [[v[s] if v is not None else None for v in all_vecs] for s in range(self.N)]
 
     def Eigenvalue(self, t0, ts=None, state=0, sort=None):
         """Determines the eigenvalue of the GEVP by solving and projecting the correlator

--- a/pyerrors/correlators.py
+++ b/pyerrors/correlators.py
@@ -241,7 +241,7 @@ class Corr:
         if self.N == 1:
             raise Exception("Trying to symmetrize a correlator matrix, that already has N=1.")
 
-    def GEVP(self, t0, ts=None, sorted_list="Eigenvalue"):
+    def GEVP(self, t0, ts=None, sort="Eigenvalue"):
         """Solve the generalized eigenvalue problem on the current correlator and returns the corresponding eigenvectors.
 
         Parameters
@@ -251,7 +251,7 @@ class Corr:
         ts : int
             fixed time G(t_s)v= lambda G(t_0)v  if return_list=False
             If return_list=True and sorting=Eigenvector it gives a reference point for the sorting method.
-        sorted_list : string
+        sort : string
             if this argument is set, a list of vectors (len=self.T) is returned. If it is left as None, only one vector is returned.
              "Eigenvalue"  -  The eigenvector is chosen according to which eigenvalue it belongs individually on every timeslice.
              "Eigenvector" -  Use the method described in arXiv:2004.10472 [hep-lat] to find the set of v(t) belonging to the state.
@@ -262,9 +262,9 @@ class Corr:
             raise Exception("GEVP methods only works on correlator matrices and not single correlators.")
 
         symmetric_corr = self.matrix_symmetric()
-        if sorted_list is None:
+        if sort is None:
             if (ts is None):
-                raise Exception("ts is required if sorted_list=None.")
+                raise Exception("ts is required if sort=None.")
             if (ts <= t0):
                 raise Exception("ts has to be larger than t0.")
             if (self.content[t0] is None) or (self.content[ts] is None):
@@ -278,8 +278,8 @@ class Corr:
             sp_vecs = _GEVP_solver(Gt, G0)
             sp_vec = [sp_vecs[s] for s in range(self.N)]
             return sp_vec
-        elif sorted_list in ["Eigenvalue", "Eigenvector"]:
-            if sorted_list == "Eigenvalue" and ts is not None:
+        elif sort in ["Eigenvalue", "Eigenvector"]:
+            if sort == "Eigenvalue" and ts is not None:
                 warnings.warn("ts has no effect when sorting by eigenvalue is chosen.", RuntimeWarning)
             all_vecs = [None] * (t0 + 1)
             for t in range(t0 + 1, self.T):
@@ -291,24 +291,24 @@ class Corr:
                             Gt[i, j] = symmetric_corr[t][i, j].value
 
                     sp_vecs = _GEVP_solver(Gt, G0)
-                    if sorted_list == "Eigenvalue":
+                    if sort == "Eigenvalue":
                         sp_vec = [sp_vecs[s] for s in range(self.N)]
                         all_vecs.append(sp_vec)
                     else:
                         all_vecs.append(sp_vecs)
                 except Exception:
                     all_vecs.append(None)
-            if sorted_list == "Eigenvector":
+            if sort == "Eigenvector":
                 if (ts is None):
                     raise Exception("ts is required for the Eigenvector sorting method.")
                 all_vecs = _sort_vectors(all_vecs, ts)
                 all_vecs = [[a[s] if a is not None else None for a in all_vecs] for s in range(self.N)]
         else:
-            raise Exception("Unkown value for 'sorted_list'.")
+            raise Exception("Unkown value for 'sort'.")
 
         return all_vecs
 
-    def Eigenvalue(self, t0, ts=None, state=0, sorted_list=None):
+    def Eigenvalue(self, t0, ts=None, state=0, sort=None):
         """Determines the eigenvalue of the GEVP by solving and projecting the correlator
 
         Parameters
@@ -320,13 +320,13 @@ class Corr:
             If return_list=True and sorting=Eigenvector it gives a reference point for the sorting method.
         state : int
             The state one is interested in ordered by energy. The lowest state is zero.
-        sorted_list : string
+        sort : string
             if this argument is set, a list of vectors (len=self.T) is returned. If it is left as None, only one vector is returned.
              "Eigenvalue"  -  The eigenvector is chosen according to which eigenvalue it belongs individually on every timeslice.
              "Eigenvector" -  Use the method described in arXiv:2004.10472 [hep-lat] to find the set of v(t) belonging to the state.
                               The reference state is identified by its eigenvalue at t=ts
         """
-        vec = self.GEVP(t0, ts=ts, sorted_list=sorted_list)[state]
+        vec = self.GEVP(t0, ts=ts, sort=sort)[state]
         return self.projected(vec)
 
     def Hankel(self, N, periodic=False):
@@ -1174,7 +1174,7 @@ class Corr:
         if basematrix.N != self.N:
             raise Exception('basematrix and targetmatrix have to be of the same size.')
 
-        evecs = basematrix.GEVP(t0proj, tproj, sorted_list=None)[:Ntrunc]
+        evecs = basematrix.GEVP(t0proj, tproj, sort=None)[:Ntrunc]
 
         tmpmat = np.empty((Ntrunc, Ntrunc), dtype=object)
         rmat = []

--- a/pyerrors/correlators.py
+++ b/pyerrors/correlators.py
@@ -314,23 +314,15 @@ class Corr:
         else:
             return reordered_vecs
 
-    def Eigenvalue(self, t0, ts=None, state=0, sort=None):
+    def Eigenvalue(self, t0, ts=None, state=0, sort="Eigenvalue"):
         """Determines the eigenvalue of the GEVP by solving and projecting the correlator
 
         Parameters
         ----------
-        t0 : int
-            The time t0 for G(t)v= lambda G(t_0)v
-        ts : int
-            fixed time G(t_s)v= lambda G(t_0)v  if return_list=False
-            If return_list=True and sorting=Eigenvector it gives a reference point for the sorting method.
         state : int
             The state one is interested in ordered by energy. The lowest state is zero.
-        sort : string
-            if this argument is set, a list of vectors (len=self.T) is returned. If it is left as None, only one vector is returned.
-             "Eigenvalue"  -  The eigenvector is chosen according to which eigenvalue it belongs individually on every timeslice.
-             "Eigenvector" -  Use the method described in arXiv:2004.10472 [hep-lat] to find the set of v(t) belonging to the state.
-                              The reference state is identified by its eigenvalue at t=ts
+
+        All other parameters are identical to the ones of Corr.GEVP.
         """
         vec = self.GEVP(t0, ts=ts, sort=sort)[state]
         return self.projected(vec)

--- a/tests/correlators_test.py
+++ b/tests/correlators_test.py
@@ -231,11 +231,10 @@ def test_matrix_corr():
     corr_mat = pe.Corr(np.array([[corr_aa, corr_ab], [corr_ab, corr_aa]]))
     corr_mat.item(0, 0)
 
-    vec_0 = corr_mat.GEVP(0, 1, sorted_list=None)
-    vec_1 = corr_mat.GEVP(0, 1, state=1, sorted_list=None)
+    vecs = corr_mat.GEVP(0, 1, sorted_list=None)
 
-    corr_0 = corr_mat.projected(vec_0)
-    corr_1 = corr_mat.projected(vec_1)
+    corr_0 = corr_mat.projected(vecs[0])
+    corr_1 = corr_mat.projected(vecs[0])
 
     assert np.all([o == 0 for o in corr_0 - corr_aa])
     assert np.all([o == 0 for o in corr_1 - corr_aa])

--- a/tests/correlators_test.py
+++ b/tests/correlators_test.py
@@ -242,11 +242,35 @@ def test_matrix_corr():
 
     corr_mat.matrix_symmetric()
 
+
+def test_GEVP_warnings():
+    corr_aa = _gen_corr(1)
+    corr_ab = 0.5 * corr_aa
+
+    corr_mat = pe.Corr(np.array([[corr_aa, corr_ab], [corr_ab, corr_aa]]))
+    corr_mat.item(0, 0)
+
     with pytest.warns(RuntimeWarning):
         corr_mat.GEVP(0, 1, sort="Eigenvalue")
 
     with pytest.warns(DeprecationWarning):
         corr_mat.GEVP(0, sorted_list="Eigenvalue")
+
+    with pytest.warns(DeprecationWarning):
+        corr_mat.GEVP(0, state=0)
+
+def test_GEVP_exceptions():
+    corr_aa = _gen_corr(1)
+    corr_ab = 0.5 * corr_aa
+
+    corr_mat = pe.Corr(np.array([[corr_aa, corr_ab], [corr_ab, corr_aa]]))
+    corr_mat.item(0, 0)
+
+    with pytest.raises(Exception):
+        corr_mat.GEVP(0, 0, sort=None)
+
+    with pytest.raises(Exception):
+        corr_mat.GEVP(1, 0, sort="Eigenvector")
 
     with pytest.raises(Exception):
         corr_mat.GEVP(0, 1, sort="This sorting method does not exist.")

--- a/tests/correlators_test.py
+++ b/tests/correlators_test.py
@@ -229,6 +229,7 @@ def test_matrix_corr():
     corr_ab = 0.5 * corr_aa
 
     corr_mat = pe.Corr(np.array([[corr_aa, corr_ab], [corr_ab, corr_aa]]))
+    corr_mat.gamma_method()
     corr_mat.item(0, 0)
 
     for (ts, sort) in zip([None, 1, 1], ["Eigenvalue", "Eigenvector", None]):
@@ -241,6 +242,8 @@ def test_matrix_corr():
     assert np.all([o == 0 for o in corr_1 - corr_aa])
 
     corr_mat.matrix_symmetric()
+    corr_mat.GEVP(0, state=0)
+    corr_mat.Eigenvalue(2, state=0)
 
 
 def test_GEVP_warnings():
@@ -264,7 +267,19 @@ def test_GEVP_exceptions():
     corr_mat.item(0, 0)
 
     with pytest.raises(Exception):
+        corr_mat.item(0, 0).projected()
+
+    with pytest.raises(Exception):
+        corr_mat.item(0, 0).GEVP(2)
+
+    with pytest.raises(Exception):
+        corr_mat.item(0, 0).matrix_symmetric()
+
+    with pytest.raises(Exception):
         corr_mat.GEVP(0, 0, sort=None)
+
+    with pytest.raises(Exception):
+        corr_mat.GEVP(0, sort=None)
 
     with pytest.raises(Exception):
         corr_mat.GEVP(1, 0, sort="Eigenvector")
@@ -276,13 +291,16 @@ def test_GEVP_exceptions():
         corr_mat.plottable()
 
     with pytest.raises(Exception):
+        corr_mat.spaghetti_plot()
+
+    with pytest.raises(Exception):
         corr_mat.show()
 
     with pytest.raises(Exception):
         corr_mat.m_eff()
 
     with pytest.raises(Exception):
-        corr_mat.Hankel()
+        corr_mat.Hankel(2)
 
     with pytest.raises(Exception):
         corr_mat.plateau()

--- a/tests/correlators_test.py
+++ b/tests/correlators_test.py
@@ -231,7 +231,7 @@ def test_matrix_corr():
     corr_mat = pe.Corr(np.array([[corr_aa, corr_ab], [corr_ab, corr_aa]]))
     corr_mat.item(0, 0)
 
-    vecs = corr_mat.GEVP(0, 1, sorted_list=None)
+    vecs = corr_mat.GEVP(0, 1, sort=None)
 
     corr_0 = corr_mat.projected(vecs[0])
     corr_1 = corr_mat.projected(vecs[0])
@@ -239,13 +239,13 @@ def test_matrix_corr():
     assert np.all([o == 0 for o in corr_0 - corr_aa])
     assert np.all([o == 0 for o in corr_1 - corr_aa])
 
-    corr_mat.GEVP(0, sorted_list="Eigenvalue")
-    corr_mat.GEVP(0, 1, sorted_list="Eigenvector")
+    corr_mat.GEVP(0, sort="Eigenvalue")
+    corr_mat.GEVP(0, 1, sort="Eigenvector")
 
     corr_mat.matrix_symmetric()
 
     with pytest.warns(RuntimeWarning):
-        corr_mat.GEVP(0, 1, sorted_list="Eigenvalue")
+        corr_mat.GEVP(0, 1, sort="Eigenvalue")
 
     with pytest.raises(Exception):
         corr_mat.plottable()

--- a/tests/correlators_test.py
+++ b/tests/correlators_test.py
@@ -231,21 +231,22 @@ def test_matrix_corr():
     corr_mat = pe.Corr(np.array([[corr_aa, corr_ab], [corr_ab, corr_aa]]))
     corr_mat.item(0, 0)
 
-    vecs = corr_mat.GEVP(0, 1, sort=None)
+    for (ts, sort) in zip([None, 1, 1], ["Eigenvalue", "Eigenvector", None]):
+        vecs = corr_mat.GEVP(0, ts=ts, sort=sort)
 
-    corr_0 = corr_mat.projected(vecs[0])
-    corr_1 = corr_mat.projected(vecs[0])
+        corr_0 = corr_mat.projected(vecs[0])
+        corr_1 = corr_mat.projected(vecs[1])
 
     assert np.all([o == 0 for o in corr_0 - corr_aa])
     assert np.all([o == 0 for o in corr_1 - corr_aa])
-
-    corr_mat.GEVP(0, sort="Eigenvalue")
-    corr_mat.GEVP(0, 1, sort="Eigenvector")
 
     corr_mat.matrix_symmetric()
 
     with pytest.warns(RuntimeWarning):
         corr_mat.GEVP(0, 1, sort="Eigenvalue")
+
+    with pytest.raises(Exception):
+        corr_mat.GEVP(0, 1, sort="This sorting method does not exist.")
 
     with pytest.raises(Exception):
         corr_mat.plottable()

--- a/tests/correlators_test.py
+++ b/tests/correlators_test.py
@@ -1,5 +1,6 @@
 import os
 import numpy as np
+import scipy
 import pyerrors as pe
 import pytest
 
@@ -288,6 +289,20 @@ def test_matrix_symmetric():
     sym_corr_mat = corr_mat.matrix_symmetric()
 
     assert np.all([np.all(o == o.T) for o in sym_corr_mat])
+
+
+def test_GEVP_solver():
+
+    mat1 = np.random.rand(15, 15)
+    mat2 = np.random.rand(15, 15)
+    mat1 = mat1 @ mat1.T
+    mat2 = mat2 @ mat2.T
+
+    sp_val, sp_vecs = scipy.linalg.eigh(mat1, mat2)
+    sp_vecs = [sp_vecs[:, np.argsort(sp_val)[-i]] for i in range(1, sp_vecs.shape[0] + 1)]
+    sp_vecs = [v / np.sqrt((v.T @ mat2 @ v)) for v in sp_vecs]
+
+    assert np.allclose(sp_vecs, pe.correlators._GEVP_solver(mat1, mat2), atol=1e-14)
 
 
 def test_hankel():

--- a/tests/correlators_test.py
+++ b/tests/correlators_test.py
@@ -245,6 +245,9 @@ def test_matrix_corr():
     with pytest.warns(RuntimeWarning):
         corr_mat.GEVP(0, 1, sort="Eigenvalue")
 
+    with pytest.warns(DeprecationWarning):
+        corr_mat.GEVP(0, sorted_list="Eigenvalue")
+
     with pytest.raises(Exception):
         corr_mat.GEVP(0, 1, sort="This sorting method does not exist.")
 

--- a/tests/correlators_test.py
+++ b/tests/correlators_test.py
@@ -256,9 +256,6 @@ def test_GEVP_warnings():
     with pytest.warns(DeprecationWarning):
         corr_mat.GEVP(0, sorted_list="Eigenvalue")
 
-    with pytest.warns(DeprecationWarning):
-        corr_mat.GEVP(0, state=0)
-
 def test_GEVP_exceptions():
     corr_aa = _gen_corr(1)
     corr_ab = 0.5 * corr_aa


### PR DESCRIPTION
I propose to make two additional **breaking** changes to `Corr.GEVP`. With my patch
- the `GEVP` method now returns all vectors instead of just the ones for a specified state. Since we compute all vectors anyways this saves unnecessary overhead and also eliminates the argument `state`. If only one state is of interest the corresponding vectors can be obtained via indexing
```
C.GEVP(t0=2)[0]  # Ground state vectors
C.GEVP(t0=2)[:3]  # Vectors for the lowest three states
```
- the argument `sorted_list` was renamed to `sort` which feels like a more meaningful name.

I also simplified the `_solve_GEVP` helper function, the functionality should be unchanged. I added a unit test which verifies this.

Opinions?

Depends on PR #99 