### PR TITLE
bugfix: Deltas in JSON file are now relative to o.value and not o.r_values[r_name]

### DIFF
--- a/pyerrors/input/json.py
+++ b/pyerrors/input/json.py
@@ -33,6 +33,7 @@ def create_json_string(ol, description='', indent=1):
 
     def _gen_data_d_from_list(ol):
         dl = []
+        No = len(ol)
         for name in ol[0].mc_names:
             ed = {}
             ed['id'] = name
@@ -43,10 +44,11 @@ def create_json_string(ol, description='', indent=1):
                 if ol[0].is_merged.get(r_name, False):
                     rd['is_merged'] = True
                 rd['deltas'] = []
+                offsets = [o.r_values[r_name] - o.value for o in ol]
+                deltas = np.column_stack([ol[oi].deltas[r_name] + offsets[oi] for oi in range(No)])
                 for i in range(len(ol[0].idl[r_name])):
                     rd['deltas'].append([ol[0].idl[r_name][i]])
-                    for o in ol:
-                        rd['deltas'][-1].append(o.deltas[r_name][i])
+                    rd['deltas'][-1] += deltas[i].tolist()
                 ed['replica'].append(rd)
             dl.append(ed)
         return dl

--- a/tests/json_io_test.py
+++ b/tests/json_io_test.py
@@ -33,11 +33,10 @@ def test_jsonio():
     mat[1][0].tag = '{testt}'
     mat[1][1].tag = '[tag]'
 
-    tt1 = pe.Obs([np.random.rand(100)], ['t|r1'], idl=[range(2, 202, 2)])
-    tt2 = pe.Obs([np.random.rand(100)], ['t|r2'], idl=[range(2, 202, 2)])
+    tt1 = pe.Obs([np.random.rand(100), np.random.rand(100)], ['t|r1', 't|r2'], idl=[range(2, 202, 2), range(22, 222, 2)])
     tt3 = pe.Obs([np.random.rand(102)], ['qe'])
 
-    tt = tt1 + tt2 + tt3
+    tt = tt1 + tt3
 
     tt.tag = 'Test Obs: Ä'
 
@@ -63,6 +62,13 @@ def test_jsonio():
         for j in range(len(or1)):
             o = or1[j] - or2[j]
             assert(o.is_zero())
+        if isinstance(ol[i], pe.Obs):
+            for name in ol[i].r_values:
+                assert(np.isclose(ol[i].r_values[name], rl[i].r_values[name]))
+        elif isinstance(ol[i], list):
+            for j in range(len(ol[i])):
+                for name in ol[i][j].r_values:
+                    assert(np.isclose(ol[i][j].r_values[name], rl[i][j].r_values[name]))
 
     description = {'I': {'Am': {'a': 'nested dictionary!'}}}
     jsonio.dump_to_json(ol, fname, indent=0, gz=False, description=description)


### PR DESCRIPTION
This fixes a bug in the JSON I/O: 

The definition of the JSON file format states that the deltas that are saved in the file are the deviations on each ensemble relative to **the mean value**. However, we did export the deviation relative to the **replica mean**. This led to a loss of information namely the mean values on the single replica, which were set to the global mean value after import.

The bug fix now ensures that the correct replica means are restored. Within the file, the deltas within one entry `'deltas'` do not sum to zero anymore, but to `r_value - value`. The sum of all deltas within one ensemble still sums up to zero. This could be used as a cross-check. I am thinking about how to implement this, together with a speedup of the import.

Old files that were written with the bug are still read correctly, however, the r_values are not restored. New files will differ from the old ones but will respect the definition of the format.

Together with the bug fix, a small change has been made to speed up the creation of `rd['deltas']`, using numpy arrays.