### PR TITLE
Bug in json format value assignment

### DIFF
--- a/pyerrors/input/json.py
+++ b/pyerrors/input/json.py
@@ -294,6 +294,7 @@ def _parse_json_dict(json_dict, verbose=True, full_output=False):
 
         if od:
             ret = Obs([[ddi[0] + values[0] for ddi in di] for di in od['deltas']], od['names'], idl=od['idl'])
+            ret._value = values[0]
             ret.is_merged = od['is_merged']
         else:
             ret = Obs([], [], means=[])
@@ -319,6 +320,7 @@ def _parse_json_dict(json_dict, verbose=True, full_output=False):
         for i in range(layout):
             if od:
                 ret.append(Obs([list(di[:, i] + values[i]) for di in od['deltas']], od['names'], idl=od['idl']))
+                ret[-1]._value = values[i]
                 ret[-1].is_merged = od['is_merged']
             else:
                 ret.append(Obs([], [], means=[]))
@@ -346,6 +348,7 @@ def _parse_json_dict(json_dict, verbose=True, full_output=False):
         for i in range(N):
             if od:
                 ret.append(Obs([di[:, i] + values[i] for di in od['deltas']], od['names'], idl=od['idl']))
+                ret[-1]._value = values[i]
                 ret[-1].is_merged = od['is_merged']
             else:
                 ret.append(Obs([], [], means=[]))


### PR DESCRIPTION
I think I found another bug which only appears in the reconstruction of observables defined on multiple replica for which the average of the `r_values` is **not** equal to the `value`. In these cases the correct value was not reconstructed but instead the average of the `r_values` was assigned.