### PR TITLE
Fix/none array entries

### DIFF
--- a/pyerrors/correlators.py
+++ b/pyerrors/correlators.py
@@ -423,13 +423,15 @@ class Corr:
             Can either be an Obs which is correlated with all entries of the
             correlator or a Corr of same length.
         """
+        if self.N != 1:
+            raise Exception("Only one-dimensional correlators can be safely correlated.")
         new_content = []
         for x0, t_slice in enumerate(self.content):
-            if t_slice is None:
+            if _check_for_none(self, t_slice):
                 new_content.append(None)
             else:
                 if isinstance(partner, Corr):
-                    if partner.content[x0] is None:
+                    if _check_for_none(partner, partner.content[x0]):
                         new_content.append(None)
                     else:
                         new_content.append(np.array([correlate(o, partner.content[x0][0]) for o in t_slice]))
@@ -453,9 +455,11 @@ class Corr:
             the reweighting factor on all configurations in weight.idl and not
             on the configurations in obs[i].idl.
         """
+        if self.N != 1:
+            raise Exception("Reweighting only implemented for one-dimensional correlators.")
         new_content = []
         for t_slice in self.content:
-            if t_slice is None:
+            if _check_for_none(self, t_slice):
                 new_content.append(None)
             else:
                 new_content.append(np.array(reweight(weight, t_slice, **kwargs)))
@@ -471,6 +475,8 @@ class Corr:
         partity : int
             Parity quantum number of the correlator, can be +1 or -1
         """
+        if self.N != 1:
+            raise Exception("T_symmetry only implemented for one-dimensional correlators.")
         if not isinstance(partner, Corr):
             raise Exception("T partner has to be a Corr object.")
         if parity not in [+1, -1]:
@@ -498,6 +504,8 @@ class Corr:
             decides which definition of the finite differences derivative is used.
             Available choice: symmetric, forward, backward, improved, default: symmetric
         """
+        if self.N != 1:
+            raise Exception("deriv only implemented for one-dimensional correlators.")
         if variant == "symmetric":
             newcontent = []
             for t in range(1, self.T - 1):
@@ -550,6 +558,8 @@ class Corr:
             decides which definition of the finite differences derivative is used.
             Available choice: symmetric, improved, default: symmetric
         """
+        if self.N != 1:
+            raise Exception("second_deriv only implemented for one-dimensional correlators.")
         if variant == "symmetric":
             newcontent = []
             for t in range(1, self.T - 1):
@@ -1224,6 +1234,7 @@ def _sort_vectors(vec_set, ts):
             sorted_vec_set.append(vec_set[t])
 
     return sorted_vec_set
+
 
 def _check_for_none(corr, entry):
     """Checks if entry for correlator corr is None"""

--- a/pyerrors/correlators.py
+++ b/pyerrors/correlators.py
@@ -197,6 +197,8 @@ class Corr:
 
     def symmetric(self):
         """ Symmetrize the correlator around x0=0."""
+        if self.N != 1:
+            raise Exception('symmetric cannot be safely applied to multi-dimensional correlators.')
         if self.T % 2 != 0:
             raise Exception("Can not symmetrize odd T")
 
@@ -215,6 +217,8 @@ class Corr:
 
     def anti_symmetric(self):
         """Anti-symmetrize the correlator around x0=0."""
+        if self.N != 1:
+            raise Exception('anti_symmetric cannot be safely applied to multi-dimensional correlators.')
         if self.T % 2 != 0:
             raise Exception("Can not symmetrize odd T")
 

--- a/pyerrors/correlators.py
+++ b/pyerrors/correlators.py
@@ -155,7 +155,7 @@ class Corr:
                 raise Exception("Vectors are of wrong shape!")
             if normalize:
                 vector_l, vector_r = vector_l / np.sqrt((vector_l @ vector_l)), vector_r / np.sqrt(vector_r @ vector_r)
-            newcontent = [None if (item is None) else np.asarray([vector_l.T @ item @ vector_r]) for item in self.content]
+            newcontent = [None if len(list(filter(None, np.asarray(item).flatten()))) < self.N ** 2 else np.asarray([vector_l.T @ item @ vector_r]) for item in self.content]
 
         else:
             # There are no checks here yet. There are so many possible scenarios, where this can go wrong.
@@ -163,7 +163,7 @@ class Corr:
                 for t in range(self.T):
                     vector_l[t], vector_r[t] = vector_l[t] / np.sqrt((vector_l[t] @ vector_l[t])), vector_r[t] / np.sqrt(vector_r[t] @ vector_r[t])
 
-            newcontent = [None if (self.content[t] is None or vector_l[t] is None or vector_r[t] is None) else np.asarray([vector_l[t].T @ self.content[t] @ vector_r[t]]) for t in range(self.T)]
+            newcontent = [None if (len(list(filter(None, np.asarray(self.content[t]).flatten()))) < self.N ** 2 or vector_l[t] is None or vector_r[t] is None) else np.asarray([vector_l[t].T @ self.content[t] @ vector_r[t]]) for t in range(self.T)]
         return Corr(newcontent)
 
     def item(self, i, j):

--- a/tests/correlators_test.py
+++ b/tests/correlators_test.py
@@ -246,13 +246,19 @@ def test_matrix_corr():
     corr_mat.Eigenvalue(2, state=0)
 
 
-def test_projected_none():
+def test_corr_none_entries():
     a = pe.pseudo_Obs(1.0, 0.1, 'a')
     l = np.asarray([[a, a], [a, a]])
     n = np.asarray([[None, None], [None, None]])
     x = [l, n]
     matr = pe.Corr(x)
     matr.projected(np.asarray([1.0, 0.0]))
+
+    matr * 2 - 2 * matr
+    matr * matr + matr ** 2 / matr
+
+    for func in [np.sqrt, np.log, np.exp, np.sin, np.cos, np.tan, np.sinh, np.cosh, np.tanh]:
+        func(matr)
 
 
 def test_GEVP_warnings():

--- a/tests/correlators_test.py
+++ b/tests/correlators_test.py
@@ -246,6 +246,15 @@ def test_matrix_corr():
     corr_mat.Eigenvalue(2, state=0)
 
 
+def test_projected_none():
+    a = pe.pseudo_Obs(1.0, 0.1, 'a')
+    l = np.asarray([[a, a], [a, a]])
+    n = np.asarray([[None, None], [None, None]])
+    x = [l, n]
+    matr = pe.Corr(x)
+    matr.projected(np.asarray([1.0, 0.0]))
+
+
 def test_GEVP_warnings():
     corr_aa = _gen_corr(1)
     corr_ab = 0.5 * corr_aa


### PR DESCRIPTION
This PR fixes a set of errors that occur in connection with `Corr` objects which have arrays containing at least one `None` object as entry.

Closes #106 