### PR TITLE
Pandas DataFrame support

### DIFF
--- a/pyerrors/input/__init__.py
+++ b/pyerrors/input/__init__.py
@@ -10,4 +10,5 @@ from . import hadrons
 from . import json
 from . import misc
 from . import openQCD
+from . import pandas
 from . import sfcf

--- a/pyerrors/input/pandas.py
+++ b/pyerrors/input/pandas.py
@@ -1,0 +1,72 @@
+import warnings
+import gzip
+import pandas as pd
+from ..obs import Obs
+from .json import create_json_string, import_json_string
+
+
+def dump_df(df, fname, gz=True):
+    """Exports a pandas DataFrame containing Obs valued columns to a (gzipped) csv file.
+
+    Before making use of pandas to_csv functionality Obs objects are serialized via the standardized
+    json format of pyerrors.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Dataframe to be dumped to a file.
+    fname : str
+        Filename of the output file.
+    gz : bool
+        If True, the output is a gzipped csv file. If False, the output is a csv file.
+    """
+
+    out = df.copy()
+    for column in out:
+        if isinstance(out[column][0], Obs):
+            out[column] = out[column].transform(lambda x: create_json_string(x, indent=0))
+
+    if not fname.endswith('.csv'):
+        fname += '.csv'
+
+    out.to_csv(fname)
+    if gz is True:
+        with open(fname, 'rb') as f_in, gzip.open(fname + ".gz", 'wb') as f_out:
+            f_out.writelines(f_in)
+
+
+def load_df(fname, auto_gamma=False, gz=True):
+    """Imports a pandas DataFrame from a csv.(gz) file in which Obs objects are serialized as json strings.
+
+    Parameters
+    ----------
+    fname : str
+        Filename of the input file.
+    auto_gamma : bool
+        If True applies the gamma_method to all imported Obs objects with the default parameters for
+        the error analysis. Default False.
+    gz : bool
+        If True, assumes that data is gzipped. If False, assumes JSON file.
+    """
+
+    if not fname.endswith('.csv') and not fname.endswith('.gz'):
+        fname += '.csv'
+
+    if gz is True:
+        if not fname.endswith('.gz'):
+            fname += '.gz'
+        with gzip.open(fname) as f:
+            re_import = pd.read_csv(f)
+    else:
+        if fname.endswith('.gz'):
+            warnings.warn("Trying to read from %s without unzipping!" % fname, UserWarning)
+        re_import = pd.read_csv(fname)
+
+    for column in re_import.select_dtypes(include="object"):
+        if isinstance(re_import[column][0], str):
+            if re_import[column][0][:20] == '{"program":"pyerrors':
+                re_import[column] = re_import[column].transform(lambda x: import_json_string(x, verbose=False))
+                if auto_gamma is True:
+                    re_import[column].apply(Obs.gamma_method)
+
+    return re_import

--- a/pyerrors/input/pandas.py
+++ b/pyerrors/input/pandas.py
@@ -30,10 +30,12 @@ def dump_df(df, fname, gz=True):
     if not fname.endswith('.csv'):
         fname += '.csv'
 
-    out.to_csv(fname, index=False)
     if gz is True:
-        with open(fname, 'rb') as f_in, gzip.open(fname + ".gz", 'wb') as f_out:
-            f_out.writelines(f_in)
+        if not fname.endswith('.gz'):
+            fname += '.gz'
+        out.to_csv(fname, index=False, compression='gzip')
+    else:
+        out.to_csv(fname, index=False)
 
 
 def load_df(fname, auto_gamma=False, gz=True):

--- a/pyerrors/input/pandas.py
+++ b/pyerrors/input/pandas.py
@@ -29,7 +29,7 @@ def dump_df(df, fname, gz=True):
     if not fname.endswith('.csv'):
         fname += '.csv'
 
-    out.to_csv(fname)
+    out.to_csv(fname, index=False)
     if gz is True:
         with open(fname, 'rb') as f_in, gzip.open(fname + ".gz", 'wb') as f_out:
             f_out.writelines(f_in)

--- a/pyerrors/input/pandas.py
+++ b/pyerrors/input/pandas.py
@@ -2,6 +2,7 @@ import warnings
 import gzip
 import pandas as pd
 from ..obs import Obs
+from ..correlators import Corr
 from .json import create_json_string, import_json_string
 
 
@@ -23,7 +24,7 @@ def dump_df(df, fname, gz=True):
 
     out = df.copy()
     for column in out:
-        if isinstance(out[column][0], Obs):
+        if isinstance(out[column][0], (Obs, Corr)):
             out[column] = out[column].transform(lambda x: create_json_string(x, indent=0))
 
     if not fname.endswith('.csv'):
@@ -67,6 +68,6 @@ def load_df(fname, auto_gamma=False, gz=True):
             if re_import[column][0][:20] == '{"program":"pyerrors':
                 re_import[column] = re_import[column].transform(lambda x: import_json_string(x, verbose=False))
                 if auto_gamma is True:
-                    re_import[column].apply(Obs.gamma_method)
+                    re_import[column].apply(lambda x: x.gamma_method())
 
     return re_import

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name='pyerrors',
       license="MIT",
       packages=find_packages(),
       python_requires='>=3.6.0',
-      install_requires=['numpy>=1.16', 'autograd>=1.4', 'numdifftools', 'matplotlib>=3.3', 'scipy>=1', 'iminuit>=2', 'h5py>=3', 'lxml>=4', 'python-rapidjson>=1'],
+      install_requires=['numpy>=1.16', 'autograd>=1.4', 'numdifftools', 'matplotlib>=3.3', 'scipy>=1', 'iminuit>=2', 'h5py>=3', 'lxml>=4', 'python-rapidjson>=1', 'pandas>=1.1'],
       classifiers=[
           'Development Status :: 5 - Production/Stable',
           'Intended Audience :: Science/Research',

--- a/tests/pandas_test.py
+++ b/tests/pandas_test.py
@@ -17,3 +17,14 @@ def test_df_export_import(tmp_path):
         pe.input.pandas.load_df((tmp_path / 'df_output.csv').as_posix(), gz=gz)
 
 
+def test_df_Corr(tmp_path):
+
+    my_corr = pe.Corr([pe.pseudo_Obs(-0.48, 0.04, "test"), pe.pseudo_Obs(-0.154, 0.03, "test")])
+
+    my_dict = {"int": 1,
+           "float": -0.01,
+           "Corr": my_corr}
+    my_df = pd.DataFrame([my_dict] * 5)
+
+    pe.input.pandas.dump_df(my_df, (tmp_path / 'df_output').as_posix())
+    reconstructed_df = pe.input.pandas.load_df((tmp_path / 'df_output').as_posix(), auto_gamma=True)

--- a/tests/pandas_test.py
+++ b/tests/pandas_test.py
@@ -1,0 +1,18 @@
+import numpy as np
+import pandas as pd
+import pyerrors as pe
+
+def test_df_export_import(tmp_path):
+    for gz in [True, False]:
+        my_df = pd.DataFrame([{"int": 1,
+                            "float": -0.01,
+                            "Obs1": pe.pseudo_Obs(87, 21, "test_ensemble"),
+                            "Obs2": pe.pseudo_Obs(-87, 21, "test_ensemble2")}])
+
+        pe.input.pandas.dump_df(my_df, (tmp_path / 'df_output').as_posix(), gz=gz)
+        reconstructed_df = pe.input.pandas.load_df((tmp_path / 'df_output').as_posix(), gz=gz)
+        assert np.all(my_df == reconstructed_df)
+
+        pe.input.pandas.load_df((tmp_path / 'df_output.csv').as_posix(), gz=gz)
+
+

--- a/tests/pandas_test.py
+++ b/tests/pandas_test.py
@@ -3,14 +3,15 @@ import pandas as pd
 import pyerrors as pe
 
 def test_df_export_import(tmp_path):
+    my_dict = {"int": 1,
+           "float": -0.01,
+           "Obs1": pe.pseudo_Obs(87, 21, "test_ensemble"),
+           "Obs2": pe.pseudo_Obs(-87, 21, "test_ensemble2")}
     for gz in [True, False]:
-        my_df = pd.DataFrame([{"int": 1,
-                            "float": -0.01,
-                            "Obs1": pe.pseudo_Obs(87, 21, "test_ensemble"),
-                            "Obs2": pe.pseudo_Obs(-87, 21, "test_ensemble2")}])
+        my_df = pd.DataFrame([my_dict] * 10)
 
         pe.input.pandas.dump_df(my_df, (tmp_path / 'df_output').as_posix(), gz=gz)
-        reconstructed_df = pe.input.pandas.load_df((tmp_path / 'df_output').as_posix(), gz=gz)
+        reconstructed_df = pe.input.pandas.load_df((tmp_path / 'df_output').as_posix(), auto_gamma=True, gz=gz)
         assert np.all(my_df == reconstructed_df)
 
         pe.input.pandas.load_df((tmp_path / 'df_output.csv').as_posix(), gz=gz)


### PR DESCRIPTION
I added export and import functionality for pandas `DataFrames` with `Obs` type columns to efficiently handle large data sets. On my local machine writing and reading O(8000) `Obs` with 9 columns of metadata (strings, ints and floats) takes less than a second each.

The serialization of the `Obs` objects is based on our standardized json format. The DataFrame is stored as a (gzipped) csv file on disk. Storage as a (gzipped) json file would work equally well but I figured that the additional metadata the json file would contain is irrelevant in this context.