### PR TITLE
is_matrix_symmetric

### DIFF
--- a/pyerrors/correlators.py
+++ b/pyerrors/correlators.py
@@ -242,6 +242,8 @@ class Corr:
         if self.N == 1:
             raise Exception("Only works for correlator matrices.")
         for t in range(self.T):
+            if self[t] is None:
+                continue
             for i in range(self.N):
                 for j in range(i + 1, self.N):
                     if self[t][i, j] is self[t][j, i]:
@@ -297,7 +299,10 @@ class Corr:
             warnings.warn("Argument 'sorted_list' is deprecated, use 'sort' instead.", DeprecationWarning)
             sort = kwargs.get("sorted_list")
 
-        symmetric_corr = self.matrix_symmetric()
+        if self.is_matrix_symmetric():
+            symmetric_corr = self
+        else:
+            symmetric_corr = self.matrix_symmetric()
         if sort is None:
             if (ts is None):
                 raise Exception("ts is required if sort=None.")

--- a/pyerrors/correlators.py
+++ b/pyerrors/correlators.py
@@ -301,7 +301,11 @@ class Corr:
             warnings.warn("Argument 'sorted_list' is deprecated, use 'sort' instead.", DeprecationWarning)
             sort = kwargs.get("sorted_list")
 
-        symmetric_corr = self.matrix_symmetric()
+        if self.is_matrix_symmetric():
+            symmetric_corr = self
+        else:
+            symmetric_corr = self.matrix_symmetric()
+
         if sort is None:
             if (ts is None):
                 raise Exception("ts is required if sort=None.")

--- a/pyerrors/correlators.py
+++ b/pyerrors/correlators.py
@@ -244,6 +244,8 @@ class Corr:
         for t in range(self.T):
             for i in range(self.N):
                 for j in range(i + 1, self.N):
+                    if self[t][i, j] is self[t][j, i]:
+                        continue
                     if hash(self[t][i, j]) != hash(self[t][j, i]):
                         return False
         return True

--- a/pyerrors/correlators.py
+++ b/pyerrors/correlators.py
@@ -254,11 +254,13 @@ class Corr:
 
     def matrix_symmetric(self):
         """Symmetrizes the correlator matrices on every timeslice."""
-        if self.N > 1:
-            transposed = [None if _check_for_none(self, G) else G.T for G in self.content]
-            return 0.5 * (Corr(transposed) + self)
         if self.N == 1:
             raise Exception("Trying to symmetrize a correlator matrix, that already has N=1.")
+        if self.is_matrix_symmetric():
+            return 1.0 * self
+        else:
+            transposed = [None if _check_for_none(self, G) else G.T for G in self.content]
+            return 0.5 * (Corr(transposed) + self)
 
     def GEVP(self, t0, ts=None, sort="Eigenvalue", **kwargs):
         r'''Solve the generalized eigenvalue problem on the correlator matrix and returns the corresponding eigenvectors.
@@ -299,10 +301,7 @@ class Corr:
             warnings.warn("Argument 'sorted_list' is deprecated, use 'sort' instead.", DeprecationWarning)
             sort = kwargs.get("sorted_list")
 
-        if self.is_matrix_symmetric():
-            symmetric_corr = self
-        else:
-            symmetric_corr = self.matrix_symmetric()
+        symmetric_corr = self.matrix_symmetric()
         if sort is None:
             if (ts is None):
                 raise Exception("ts is required if sort=None.")

--- a/pyerrors/correlators.py
+++ b/pyerrors/correlators.py
@@ -237,6 +237,17 @@ class Corr:
             raise Exception("Corr could not be symmetrized: No redundant values")
         return Corr(newcontent, prange=self.prange)
 
+    def is_matrix_symmetric(self):
+        """Checks whether a correlator matrices is symmetric on every timeslice."""
+        if self.N == 1:
+            raise Exception("Only works for correlator matrices.")
+        for t in range(self.T):
+            for i in range(self.N):
+                for j in range(i + 1, self.N):
+                    if hash(self[t][i, j]) != hash(self[t][j, i]):
+                        return False
+        return True
+
     def matrix_symmetric(self):
         """Symmetrizes the correlator matrices on every timeslice."""
         if self.N > 1:

--- a/tests/correlators_test.py
+++ b/tests/correlators_test.py
@@ -378,7 +378,7 @@ def test_is_matrix_symmetric():
                 if i != j:
                     mat[j, i] = obs
         corr_data.append(mat)
-    corr = pe.Corr(corr_data)
+    corr = pe.Corr(corr_data, padding=[0, 2])
 
     assert corr.is_matrix_symmetric()
     corr[0][0, 1] = 1.0 * corr[0][0, 1]

--- a/tests/correlators_test.py
+++ b/tests/correlators_test.py
@@ -367,6 +367,28 @@ def test_matrix_symmetric():
     corr3.matrix_symmetric()
 
 
+def test_is_matrix_symmetric():
+    corr_data = []
+    for t in range(4):
+        mat = np.zeros((4, 4), dtype=object)
+        for i in range(4):
+            for j in range(i, 4):
+                obs = pe.pseudo_Obs(0.1, 0.047, "rgetrasrewe53455b153v13v5/*/*sdfgb")
+                mat[i, j] = obs
+                if i != j:
+                    mat[j, i] = obs
+        corr_data.append(mat)
+    corr = pe.Corr(corr_data)
+
+    assert corr.is_matrix_symmetric()
+    corr[0][0, 1] = 1.0 * corr[0][0, 1]
+    assert corr.is_matrix_symmetric()
+    corr[3][2, 1] = (1 + 1e-14) * corr[3][2, 1]
+    assert corr.is_matrix_symmetric()
+    corr[0][0, 1] = 1.1 * corr[0][0, 1]
+    assert not corr.is_matrix_symmetric()
+
+
 def test_GEVP_solver():
 
     mat1 = np.random.rand(15, 15)


### PR DESCRIPTION
I implemented a new method `is_matrix_symmetric` which uses the new hash function to efficiently check whether a correlator matrix is symmetric. This check is now performed within `matrix_symmetric` and speeds up the method in case the matrix is already symmetric. This in turn accelerates the GEVP method which always calls `matrix_symmetric`.