### PR TITLE
Least square fit with numerical differentiation

### DIFF
--- a/pyerrors/fits.py
+++ b/pyerrors/fits.py
@@ -165,6 +165,8 @@ def total_least_squares(x, y, func, silent=False, **kwargs):
         corrected by effects caused by correlated input data.
         This can take a while as the full correlation matrix
         has to be calculated (default False).
+    num_grad : bool
+        Use numerical differentation instead of automatic differentiation to perform the error propagation (default False).
 
     Notes
     -----
@@ -179,7 +181,12 @@ def total_least_squares(x, y, func, silent=False, **kwargs):
 
     x_shape = x.shape
 
-    jacobian = auto_jacobian
+    if kwargs.get('num_grad') is True:
+        jacobian = num_jacobian
+        hessian = num_hessian
+    else:
+        jacobian = auto_jacobian
+        hessian = auto_hessian
 
     if not callable(func):
         raise TypeError('func has to be a function.')
@@ -275,7 +282,7 @@ def total_least_squares(x, y, func, silent=False, **kwargs):
 
     fitp = out.beta
     try:
-        hess = jacobian(jacobian(odr_chisquare))(np.concatenate((fitp, out.xplus.ravel())))
+        hess = hessian(odr_chisquare)(np.concatenate((fitp, out.xplus.ravel())))
     except TypeError:
         raise Exception("It is required to use autograd.numpy instead of numpy within fit functions, see the documentation for details.") from None
 
@@ -284,7 +291,7 @@ def total_least_squares(x, y, func, silent=False, **kwargs):
         chisq = anp.sum(((y_f - model) / dy_f) ** 2) + anp.sum(((d[n_parms + m:].reshape(x_shape) - d[n_parms:n_parms + m].reshape(x_shape)) / dx_f) ** 2)
         return chisq
 
-    jac_jac_x = jacobian(jacobian(odr_chisquare_compact_x))(np.concatenate((fitp, out.xplus.ravel(), x_f.ravel())))
+    jac_jac_x = hessian(odr_chisquare_compact_x)(np.concatenate((fitp, out.xplus.ravel(), x_f.ravel())))
 
     # Compute hess^{-1} @ jac_jac_x[:n_parms + m, n_parms + m:] using LAPACK dgesv
     try:
@@ -297,7 +304,7 @@ def total_least_squares(x, y, func, silent=False, **kwargs):
         chisq = anp.sum(((d[n_parms + m:] - model) / dy_f) ** 2) + anp.sum(((x_f - d[n_parms:n_parms + m].reshape(x_shape)) / dx_f) ** 2)
         return chisq
 
-    jac_jac_y = jacobian(jacobian(odr_chisquare_compact_y))(np.concatenate((fitp, out.xplus.ravel(), y_f)))
+    jac_jac_y = hessian(odr_chisquare_compact_y)(np.concatenate((fitp, out.xplus.ravel(), y_f)))
 
     # Compute hess^{-1} @ jac_jac_y[:n_parms + m, n_parms + m:] using LAPACK dgesv
     try:
@@ -326,9 +333,9 @@ def _prior_fit(x, y, func, priors, silent=False, **kwargs):
     x = np.asarray(x)
 
     if kwargs.get('num_grad') is True:
-        jacobian = num_jacobian
+        hessian = num_hessian
     else:
-        jacobian = auto_jacobian
+        hessian = auto_hessian
 
     if not callable(func):
         raise TypeError('func has to be a function.')
@@ -418,7 +425,7 @@ def _prior_fit(x, y, func, priors, silent=False, **kwargs):
     if not m.fmin.is_valid:
         raise Exception('The minimization procedure did not converge.')
 
-    hess = jacobian(jacobian(chisqfunc))(params)
+    hess = hessian(chisqfunc)(params)
     if kwargs.get('num_grad') is True:
         hess = hess[0]
     hess_inv = np.linalg.pinv(hess)
@@ -428,7 +435,7 @@ def _prior_fit(x, y, func, priors, silent=False, **kwargs):
         chisq = anp.sum(((d[n_parms: n_parms + len(x)] - model) / dy_f) ** 2) + anp.sum(((d[n_parms + len(x):] - d[:n_parms]) / dp_f) ** 2)
         return chisq
 
-    jac_jac = jacobian(jacobian(chisqfunc_compact))(np.concatenate((params, y_f, p_f)))
+    jac_jac = hessian(chisqfunc_compact)(np.concatenate((params, y_f, p_f)))
     if kwargs.get('num_grad') is True:
         jac_jac = jac_jac[0]
 

--- a/pyerrors/fits.py
+++ b/pyerrors/fits.py
@@ -426,8 +426,6 @@ def _prior_fit(x, y, func, priors, silent=False, **kwargs):
         raise Exception('The minimization procedure did not converge.')
 
     hess = hessian(chisqfunc)(params)
-    if kwargs.get('num_grad') is True:
-        hess = hess[0]
     hess_inv = np.linalg.pinv(hess)
 
     def chisqfunc_compact(d):

--- a/pyerrors/fits.py
+++ b/pyerrors/fits.py
@@ -434,8 +434,6 @@ def _prior_fit(x, y, func, priors, silent=False, **kwargs):
         return chisq
 
     jac_jac = hessian(chisqfunc_compact)(np.concatenate((params, y_f, p_f)))
-    if kwargs.get('num_grad') is True:
-        jac_jac = jac_jac[0]
 
     deriv = -hess_inv @ jac_jac[:n_parms, n_parms:]
 

--- a/tests/fits_test.py
+++ b/tests/fits_test.py
@@ -90,8 +90,8 @@ def test_fit_num_grad():
         x.append(i * 0.01)
         y.append(pe.pseudo_Obs(i * 0.01, 0.0001, "ens"))
 
-    num = pe.fits.least_squares(x, y, lambda a, x: a[0] * np.exp(x) + a[1], num_grad=True)
-    auto = pe.fits.least_squares(x, y, lambda a, x: a[0] * anp.exp(x) + a[1], num_grad=False)
+    num = pe.fits.least_squares(x, y, lambda a, x: np.exp(a[0] * x) + a[1], num_grad=True)
+    auto = pe.fits.least_squares(x, y, lambda a, x: anp.exp(a[0] * x) + a[1], num_grad=False)
 
     assert(num[0] == auto[0])
     assert(num[1] == auto[1])

--- a/tests/fits_test.py
+++ b/tests/fits_test.py
@@ -97,6 +97,35 @@ def test_least_squares_num_grad():
     assert(num[1] == auto[1])
 
 
+def test_prior_fit_num_grad():
+    x = []
+    y = []
+    for i in range(2, 5):
+        x.append(i * 0.01)
+        y.append(pe.pseudo_Obs(i * 0.01, 0.0001, "ens"))
+
+    num = pe.fits.least_squares(x, y, lambda a, x: np.exp(a[0] * x) + a[1], num_grad=True, priors=y[:2])
+    auto = pe.fits.least_squares(x, y, lambda a, x: anp.exp(a[0] * x) + a[1], num_grad=False, piors=y[:2])
+
+
+def test_least_squares_num_grad():
+    x = []
+    y = []
+    for i in range(2, 5):
+        x.append(i * 0.01)
+        y.append(pe.pseudo_Obs(i * 0.01, 0.0001, "ens"))
+
+    num = pe.fits.least_squares(x, y, lambda a, x: np.exp(a[0] * x) + a[1], num_grad=True)
+    auto = pe.fits.least_squares(x, y, lambda a, x: anp.exp(a[0] * x) + a[1], num_grad=False)
+
+    assert(num[0] == auto[0])
+    assert(num[1] == auto[1])
+
+
+    assert(num[0] == auto[0])
+    assert(num[1] == auto[1])
+
+
 def test_total_least_squares_num_grad():
     x = []
     y = []

--- a/tests/fits_test.py
+++ b/tests/fits_test.py
@@ -83,8 +83,22 @@ def test_least_squares():
         assert math.isclose(pcov[i, i], betac[i].dvalue ** 2, abs_tol=1e-3)
 
 
+def test_fit_num_grad():
+    x = []
+    y = []
+    for i in range(2, 5):
+        x.append(i * 0.01)
+        y.append(pe.pseudo_Obs(i * 0.01, 0.0001, "ens"))
+
+    num = pe.fits.least_squares(x, y, lambda a, x: a[0] * np.exp(x) + a[1], num_grad=True)
+    auto = pe.fits.least_squares(x, y, lambda a, x: a[0] * anp.exp(x) + a[1], num_grad=False)
+
+    assert(num[0] == auto[0])
+    assert(num[1] == auto[1])
+
+
 def test_alternative_solvers():
-    dim = 192
+    dim = 92
     x = np.arange(dim)
     y = 2 * np.exp(-0.06 * x) + np.random.normal(0.0, 0.15, dim)
     yerr = 0.1 + 0.1 * np.random.rand(dim)
@@ -158,7 +172,7 @@ def test_correlated_fit():
 
 
 def test_fit_corr_independent():
-    dim = 50
+    dim = 30
     x = np.arange(dim)
     y = 0.84 * np.exp(-0.12 * x) + np.random.normal(0.0, 0.1, dim)
     yerr = [0.1] * dim
@@ -470,7 +484,7 @@ def test_correlated_fit_vs_jackknife():
 
 
 def test_fit_no_autograd():
-    dim = 10
+    dim = 3
     x = np.arange(dim)
     y = 2 * np.exp(-0.08 * x) + np.random.normal(0.0, 0.15, dim)
     yerr = 0.1 + 0.1 * np.random.rand(dim)
@@ -485,6 +499,8 @@ def test_fit_no_autograd():
 
     with pytest.raises(Exception):
         pe.least_squares(x, oy, func)
+
+    pe.least_squares(x, oy, func, num_grad=True)
 
     with pytest.raises(Exception):
         pe.total_least_squares(oy, oy, func)

--- a/tests/fits_test.py
+++ b/tests/fits_test.py
@@ -83,7 +83,7 @@ def test_least_squares():
         assert math.isclose(pcov[i, i], betac[i].dvalue ** 2, abs_tol=1e-3)
 
 
-def test_fit_num_grad():
+def test_least_squares_num_grad():
     x = []
     y = []
     for i in range(2, 5):
@@ -92,6 +92,20 @@ def test_fit_num_grad():
 
     num = pe.fits.least_squares(x, y, lambda a, x: np.exp(a[0] * x) + a[1], num_grad=True)
     auto = pe.fits.least_squares(x, y, lambda a, x: anp.exp(a[0] * x) + a[1], num_grad=False)
+
+    assert(num[0] == auto[0])
+    assert(num[1] == auto[1])
+
+
+def test_total_least_squares_num_grad():
+    x = []
+    y = []
+    for i in range(2, 5):
+        x.append(pe.pseudo_Obs(i * 0.01, 0.0001, "ens"))
+        y.append(pe.pseudo_Obs(i * 0.01, 0.0001, "ens"))
+
+    num = pe.fits.total_least_squares(x, y, lambda a, x: np.exp(a[0] * x) + a[1], num_grad=True)
+    auto = pe.fits.total_least_squares(x, y, lambda a, x: anp.exp(a[0] * x) + a[1], num_grad=False)
 
     assert(num[0] == auto[0])
     assert(num[1] == auto[1])


### PR DESCRIPTION
I implemented the option to perform the error propagation for least squares fits with numerical differentiation instead of automatic differentiation. Using this option is ~~considerably~~ slower but can deal with fit functions which contain special functions or which are not analytically known.