### PR TITLE
feat: Speed up covariance for irregular MC chains

### DIFF
--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -534,7 +534,7 @@ def test_merge_intersection():
         assert pe.obs._merge_idx(idl_list) == pe.obs._intersection_idx(idl_list)
 
 
-def test_intersection_collapse():
+def test_intersection_reduce():
     range1 = range(1, 2000, 2)
     range2 = range(2, 2001, 8)
 
@@ -542,7 +542,7 @@ def test_intersection_collapse():
     obs_merge = obs1 + pe.Obs([np.random.normal(1.0, 0.1, len(range2))], ["ens"], idl=[range2])
 
     intersection = pe.obs._intersection_idx([o.idl["ens"] for o in [obs1, obs_merge]])
-    coll = pe.obs._collapse_deltas_for_merge(obs_merge.deltas["ens"], obs_merge.idl["ens"], len(obs_merge.idl["ens"]), range1)
+    coll = pe.obs._reduce_deltas(obs_merge.deltas["ens"], obs_merge.idl["ens"], range1)
 
     assert np.all(coll == obs1.deltas["ens"])
 


### PR DESCRIPTION
This PR speeds up the computation of covariance by orders of magnitude, when irregular MC chains are involved.

I removed `_collapse_deltas_for_merge` as it did the same job as `_reduce_deltas`. I also improved the implementation of `_reduce_deltas`, mainly by changing two things:

- I now use `groupby` to check if to `idx` are equal. For covariance matrices of correlators, this means that no reduction has to be performed, at all. In principle, this is already checked in `_intersection_idx` within `_covariance_element` such that we could do some rewriting: Export a boolean that tells you if all lists are equal when calling `_intersection_idx` and use this to skip the call for the reduction in `calc_gamma`. However, I have the impression that the comparison using groupby is very efficient (less than 1µs for realistic cases) such that it is okay to check this anyways. In this way, `reweight` should also profit from the speedup.
- I removed my manual matching of the `idx` to select the correct deltas by using `numpy.intersect1d`. I think that this should be the most efficient way to do it and I see a significant speedup w.r.t. the old implementation and even more so w.r.t `_collapse_deltas_for_merge`.