### PR TITLE
Fix details w/ no autocorrelation

### DIFF
--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -699,8 +699,6 @@ class Obs:
         return 'Obs[' + str(self) + ']'
 
     def __str__(self):
-        if self._dvalue == 0.0:
-            return str(self.value)
         return _format_uncertainty(self.value, self._dvalue)
 
     def __hash__(self):
@@ -979,6 +977,8 @@ class CObs:
 
 def _format_uncertainty(value, dvalue):
     """Creates a string of a value and its error in paranthesis notation, e.g., 13.02(45)"""
+    if dvalue == 0.0:
+        return str(value)
     fexp = np.floor(np.log10(dvalue))
     if fexp < 0.0:
         return '{:{form}}({:2.0f})'.format(value, dvalue * 10 ** (-fexp + 1), form='.' + str(-int(fexp) + 1) + 'f')

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -998,6 +998,12 @@ def test_cobs_array():
     cobs / np.ones((4, 4))
 
 
+def test_details_tau_no_error():
+    tt = pe.Obs([np.random.rand(500)], ["ens"])
+    tt.gamma_method(S=0)
+    tt.details()
+
+
 def test_hash():
     obs = pe.pseudo_Obs(0.3, 0.1, "test") + pe.Obs([np.random.normal(2.3, 0.2, 200)], ["test2"], [range(1, 400, 2)])
     o1 = obs + pe.cov_Obs(0.0, 0.1, "co") + pe.cov_Obs(0.0, 0.8, "co2")


### PR DESCRIPTION
This PR fixes a bug that appears when calling `Obs.details` on an observable for which the integrated autocorrelation time was determined to be 0.5 with zero error.