### PR TITLE
feat: JSON export can handle numpy.int64 entries

### DIFF
--- a/pyerrors/input/json.py
+++ b/pyerrors/input/json.py
@@ -186,10 +186,15 @@ def create_json_string(ol, description='', indent=1):
         else:
             raise Exception("Unkown datatype.")
 
+    def _jsonifier(o):
+        if isinstance(o, np.int64):
+            return int(o)
+        raise TypeError('%r is not JSON serializable' % o)
+
     if indent:
-        return json.dumps(d, indent=indent, ensure_ascii=False, write_mode=json.WM_SINGLE_LINE_ARRAY)
+        return json.dumps(d, indent=indent, ensure_ascii=False, default=_jsonifier, write_mode=json.WM_SINGLE_LINE_ARRAY)
     else:
-        return json.dumps(d, indent=indent, ensure_ascii=False, write_mode=json.WM_COMPACT)
+        return json.dumps(d, indent=indent, ensure_ascii=False, default=_jsonifier, write_mode=json.WM_COMPACT)
 
 
 def dump_to_json(ol, fname, description='', indent=1, gz=True):


### PR DESCRIPTION
This change handles cases where entries of the data structure that is to be exported to a JSON file, e.g., via `pe.input.json.dump_dict_to_json` contains a `numpy.int64`. Before, an error has been thrown, because the `dunps` function now gets a plain `int` via the type conversion. If any more such cases exist, they could be included in the new function `_jsonifier'.