### PR TITLE
fix: corrected small bug in qtop_projection with several replica

### DIFF
--- a/pyerrors/input/openQCD.py
+++ b/pyerrors/input/openQCD.py
@@ -929,7 +929,7 @@ def qtop_projection(qtop, target=0):
 
     proj_qtop = []
     for n in qtop.deltas:
-        proj_qtop.append(np.array([1 if round(qtop.value + q) == target else 0 for q in qtop.deltas[n]]))
+        proj_qtop.append(np.array([1 if round(qtop.r_values[n] + q) == target else 0 for q in qtop.deltas[n]]))
 
     reto = Obs(proj_qtop, qtop.names, idl=[qtop.idl[name] for name in qtop.names])
     reto.is_merged = qtop.is_merged


### PR DESCRIPTION
The projection to sectors of the topological charge was not done correctly in the case of several replica because the value of the primary observable had been extracted from the mean and not the replica mean. 

The impact of this bug is expected to be very minor since it only has an impact, if the difference between mean and replica mean leads to a shift from one sector to the other. 