### PR TITLE
Remove attribute is_merged

### DIFF
--- a/pyerrors/input/json.py
+++ b/pyerrors/input/json.py
@@ -41,8 +41,6 @@ def create_json_string(ol, description='', indent=1):
             for r_name in ol[0].e_content[name]:
                 rd = {}
                 rd['name'] = r_name
-                if ol[0].is_merged.get(r_name, False):
-                    rd['is_merged'] = True
                 rd['deltas'] = []
                 offsets = [o.r_values[r_name] - o.value for o in ol]
                 deltas = np.column_stack([ol[oi].deltas[r_name] + offsets[oi] for oi in range(No)])
@@ -138,7 +136,6 @@ def create_json_string(ol, description='', indent=1):
         for name in obs._covobs:
             my_obs.names.append(name)
         my_obs.reweighted = obs.reweighted
-        my_obs.is_merged = obs.is_merged
         return my_obs
 
     def write_Corr_to_dict(my_corr):
@@ -258,7 +255,6 @@ def _parse_json_dict(json_dict, verbose=True, full_output=False):
             retd['names'] = []
             retd['idl'] = []
             retd['deltas'] = []
-            retd['is_merged'] = {}
             for ens in d:
                 for rep in ens['replica']:
                     rep_name = rep['name']
@@ -270,7 +266,6 @@ def _parse_json_dict(json_dict, verbose=True, full_output=False):
                     retd['names'].append(rep_name)
                     retd['idl'].append([di[0] for di in rep['deltas']])
                     retd['deltas'].append(np.array([di[1:] for di in rep['deltas']]))
-                    retd['is_merged'][rep_name] = rep.get('is_merged', False)
         return retd
 
     def _gen_covobsd_from_cdatad(d):
@@ -300,7 +295,6 @@ def _parse_json_dict(json_dict, verbose=True, full_output=False):
         if od:
             ret = Obs([[ddi[0] + values[0] for ddi in di] for di in od['deltas']], od['names'], idl=od['idl'])
             ret._value = values[0]
-            ret.is_merged = od['is_merged']
         else:
             ret = Obs([], [], means=[])
             ret._value = values[0]
@@ -326,7 +320,6 @@ def _parse_json_dict(json_dict, verbose=True, full_output=False):
             if od:
                 ret.append(Obs([list(di[:, i] + values[i]) for di in od['deltas']], od['names'], idl=od['idl']))
                 ret[-1]._value = values[i]
-                ret[-1].is_merged = od['is_merged']
             else:
                 ret.append(Obs([], [], means=[]))
                 ret[-1]._value = values[i]
@@ -354,7 +347,6 @@ def _parse_json_dict(json_dict, verbose=True, full_output=False):
             if od:
                 ret.append(Obs([di[:, i] + values[i] for di in od['deltas']], od['names'], idl=od['idl']))
                 ret[-1]._value = values[i]
-                ret[-1].is_merged = od['is_merged']
             else:
                 ret.append(Obs([], [], means=[]))
                 ret[-1]._value = values[i]

--- a/pyerrors/input/openQCD.py
+++ b/pyerrors/input/openQCD.py
@@ -932,7 +932,6 @@ def qtop_projection(qtop, target=0):
         proj_qtop.append(np.array([1 if round(qtop.r_values[n] + q) == target else 0 for q in qtop.deltas[n]]))
 
     reto = Obs(proj_qtop, qtop.names, idl=[qtop.idl[name] for name in qtop.names])
-    reto.is_merged = qtop.is_merged
     return reto
 
 

--- a/pyerrors/misc.py
+++ b/pyerrors/misc.py
@@ -109,7 +109,7 @@ def _assert_equal_properties(ol, otype=Obs):
     for o in ol[1:]:
         if not isinstance(o, otype):
             raise Exception("Wrong data type in list.")
-        for attr in ["is_merged", "reweighted", "e_content", "idl"]:
+        for attr in ["reweighted", "e_content", "idl"]:
             if hasattr(ol[0], attr):
                 if not getattr(ol[0], attr) == getattr(o, attr):
                     raise Exception(f"All Obs in list have to have the same state '{attr}'.")

--- a/tests/correlators_test.py
+++ b/tests/correlators_test.py
@@ -542,3 +542,13 @@ def test_complex_Corr():
     print(ccorr)
     mcorr = pe.Corr(np.array([[ccorr, ccorr], [ccorr, ccorr]]))
     assert np.all([mcorr.imag[i] == -mcorr.real[i] for i in range(mcorr.T)])
+
+
+def test_corr_no_filtering():
+    li = [-pe.pseudo_Obs(.2, .1, 'a', samples=10) for i in range(96)]
+    for i in range(len(li)):
+        li[i].idl['a'] = range(1, 21, 2)
+    c= pe.Corr(li)
+    b = pe.pseudo_Obs(1, 1e-11, 'a', samples=30)
+    c *= b
+    assert np.all([c[0].idl == o.idl for o in c])

--- a/tests/json_io_test.py
+++ b/tests/json_io_test.py
@@ -404,11 +404,4 @@ def assert_equal_Obs(to, ro):
             if not np.allclose(v, v2, atol=1e-14):
                 print(kw, "does not match.")
                 return False
-
-    m_to = getattr(to, "is_merged")
-    m_ro = getattr(ro, "is_merged")
-    if not m_to == m_ro:
-        if not (all(value is False for value in m_ro.values()) and all(value is False for value in m_to.values())):
-            print("is_merged", "does not match.")
-            return False
     return True

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -201,8 +201,6 @@ def test_matmul_irregular_histories():
         t2 = pe.linalg.matmul(standard_matrix, irregular_matrix)
 
         assert np.all([o.is_zero() for o in (t1 - t2).ravel()])
-        assert np.all([o.is_merged for o in t1.ravel()])
-        assert np.all([o.is_merged for o in t2.ravel()])
 
 
 def test_irregular_matrix_inverse():


### PR DESCRIPTION
This PR removes the `Obs` attribute `is_merged` which is no longer needed after the removal of `_filter_zeroes`. On my machine, on python 3.8 this results in a ~1.15x speed up for the multiplication of two `Obs`. 