### PR TITLE
Wrapper for errorbar matplotlib method

### DIFF
--- a/pyerrors/misc.py
+++ b/pyerrors/misc.py
@@ -4,38 +4,35 @@ import matplotlib.pyplot as plt
 from .obs import Obs
 
 
-def errorbar(x, y, axes=plt, *args, **kwargs):
-    """pyerrors wrapper for the errorbars method fo matplotlib
+def errorbar(x, y, axes=plt, **kwargs):
+    """pyerrors wrapper for the errorbars method of matplotlib
 
     Parameters
     ----------
     x : list
-        A list of x-values. It can be a list of Obs objects or int/float.
+        A list of x-values which can be Obs.
     y : list
-        A list of y-values. It should be a list of Obs objects.
+        A list of y-values which can be Obs.
     axes : (matplotlib.pyplot.axes)
         The axes to plot on. default is plt.
     """
-    if not all(isinstance(o, Obs) for o in y):
-        raise Exception("All entries of 'y' have to be Obs")
+    val = {}
+    err = {}
+    for name, comp in zip(["x", "y"], [x, y]):
+        if all(isinstance(o, Obs) for o in comp):
+            if not all(hasattr(o, 'e_dvalue') for o in comp):
+                [o.gamma_method() for o in comp]
+            val[name] = [o.value for o in comp]
+            err[name] = [o.dvalue for o in comp]
+        else:
+            val[name] = comp
+            err[name] = None
 
-    if all(isinstance(o, Obs) for o in x):
-        if not all(hasattr(o, 'e_dvalue') for o in x):
-            [o.gamma_method() for o in x]
-        xval = [o.value for o in x]
-        xerr = [o.dvalue for o in x]
-    elif all(isinstance(o, (int, float, np.integer)) for o in x):
-        xval = x
-        xerr = None
-    else:
-        raise Exception("All entries of 'x' have to be of the same type (int, float or Obs)")
+        if f"{name}err" in kwargs:
+            err[name] = kwargs.get(f"{name}err")
+            kwargs.pop(f"{name}err", None)
 
-    if not all(hasattr(o, 'e_dvalue') for o in y):
-        [o.gamma_method() for o in y]
-    yval = [o.value for o in y]
-    yerr = [o.dvalue for o in y]
-
-    axes.errorbar(xval, yval, *args, xerr=xerr, yerr=yerr, **kwargs)
+    axes.errorbar(val["x"], val["y"], xerr=err["x"], yerr=err["y"], **kwargs)
 
 
 def dump_object(obj, name, **kwargs):

--- a/pyerrors/misc.py
+++ b/pyerrors/misc.py
@@ -1,6 +1,41 @@
 import pickle
 import numpy as np
+import matplotlib.pyplot as plt
 from .obs import Obs
+
+
+def errorbar(x, y, axes=plt, *args, **kwargs):
+    """pyerrors wrapper for the errorbars method fo matplotlib
+
+    Parameters
+    ----------
+    x : list
+        A list of x-values. It can be a list of Obs objects or int/float.
+    y : list
+        A list of y-values. It should be a list of Obs objects.
+    axes : (matplotlib.pyplot.axes)
+        The axes to plot on. default is plt.
+    """
+    if not all(isinstance(o, Obs) for o in y):
+        raise Exception("All entries of 'y' have to be Obs")
+
+    if all(isinstance(o, Obs) for o in x):
+        if not all(hasattr(o, 'e_dvalue') for o in x):
+            [o.gamma_method() for o in x]
+        xval = [o.value for o in x]
+        xerr = [o.dvalue for o in x]
+    elif all(isinstance(o, (int, float, np.integer)) for o in x):
+        xval = x
+        xerr = None
+    else:
+        raise Exception("All entries of 'x' have to be of the same type (int, float or Obs)")
+
+    if not all(hasattr(o, 'e_dvalue') for o in y):
+        [o.gamma_method() for o in y]
+    yval = [o.value for o in y]
+    yerr = [o.dvalue for o in y]
+
+    axes.errorbar(xval, yval, *args, xerr=xerr, yerr=yerr, **kwargs)
 
 
 def dump_object(obj, name, **kwargs):

--- a/tests/misc_test.py
+++ b/tests/misc_test.py
@@ -1,0 +1,17 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import pyerrors as pe
+import pytest
+
+
+def test_obs_errorbar():
+    x_float = np.arange(5)
+    x_obs = []
+    y_obs = []
+    for x in x_float:
+        x_obs.append(pe.pseudo_Obs(x, 0.1, "test"))
+        y_obs.append(pe.pseudo_Obs(x ** 2, 0.1, "test"))
+
+    pe.errorbar(x_float, y_obs, marker="x", ms=2)
+    pe.errorbar(x_obs, y_obs, marker="x", ms=2)
+

--- a/tests/misc_test.py
+++ b/tests/misc_test.py
@@ -12,6 +12,9 @@ def test_obs_errorbar():
         x_obs.append(pe.pseudo_Obs(x, 0.1, "test"))
         y_obs.append(pe.pseudo_Obs(x ** 2, 0.1, "test"))
 
-    pe.errorbar(x_float, y_obs, marker="x", ms=2)
-    pe.errorbar(x_obs, y_obs, marker="x", ms=2)
+    for xerr in [2, None]:
+        for yerr in [0.1, None]:
+            pe.errorbar(x_float, y_obs, marker="x", ms=2, xerr=xerr, yerr=yerr)
+            pe.errorbar(x_obs, y_obs, marker="x", ms=2, xerr=xerr, yerr=yerr)
 
+    plt.close('all')


### PR DESCRIPTION
I added a wrapper around `plt.errorbar` or `Axes.errorbar` for use with `Obs` objects which should save a bit of time everytime one tries to plot and Obs valued list or array.

Usage:
```python
import matplotlib.pyplot as plt
import pyerrors as pe

...

pe.errorbar(x, y, marker="o")
plt.show()

or

fig = plt.figure()
ax1 = fig.add_subplot(111)
pe.errorbar(x, y, marker="o", axes=ax1)
plt.show()
```