### PR TITLE
Fix non overlapping configurations

### DIFF
--- a/pyerrors/input/dobs.py
+++ b/pyerrors/input/dobs.py
@@ -454,7 +454,6 @@ def import_dobs_string(content, full_output=False, separator_insertion=True):
     _check(dobs[4].tag == "ne")
     ne = int(dobs[4].text.strip())
     _check(dobs[5].tag == "nc")
-    nc = int(dobs[5].text.strip())
 
     idld = {}
     deltad = {}

--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -1097,7 +1097,7 @@ def _expand_deltas_for_merge(deltas, idx, shape, new_idx):
     ret = np.zeros(new_idx[-1] - new_idx[0] + 1)
     for i in range(shape):
         ret[idx[i] - new_idx[0]] = deltas[i]
-    return np.array([ret[new_idx[i] - new_idx[0]] for i in range(len(new_idx))])
+    return np.array([ret[new_idx[i] - new_idx[0]] for i in range(len(new_idx))]) * len(new_idx) / len(idx)
 
 
 def derived_observable(func, data, array_mode=False, **kwargs):

--- a/tests/json_io_test.py
+++ b/tests/json_io_test.py
@@ -339,7 +339,7 @@ def test_dobsio():
 
     dobsio.write_dobs(ol, fname, 'TEST')
 
-    rl = dobsio.read_dobs(fname, noempty=True)
+    rl = dobsio.read_dobs(fname)
     os.remove(fname + '.xml.gz')
     [o.gamma_method() for o in rl]
 

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -1086,19 +1086,30 @@ def test_non_overlapping_missing_cnfgs():
     assert np.isclose(full.dvalue, average.dvalue, rtol=0.01)
 
 
-def test_non_overlapping_product():
+def test_non_overlapping_operations():
     length = 100000
 
     samples = np.random.normal(0.93, 0.5, length)
 
     e = pe.Obs([samples[0:length:2]], ["ensemble"], idl=[range(0, length, 2)])
     o = pe.Obs([samples[1:length:2]], ["ensemble"], idl=[range(1, length, 2)])
-    prod1 = e * o
-    prod1.gm(S=0)
+
 
     e2 = pe.Obs([samples[0:length:2]], ["even"])
     o2 = pe.Obs([samples[1:length:2]], ["odd"])
-    prod2 = e2 * o2
-    prod2.gm(S=0)
 
-    assert np.isclose(prod1.dvalue, prod2.dvalue, rtol=0.01)
+    for func in  [lambda a, b: a + b,
+                  lambda a, b: a - b,
+                  lambda a, b: a * b,
+                  lambda a, b: a / b,
+                  lambda a, b: a ** b]:
+
+        res1 = func(e, o)
+        res1.gm(S=0)
+        res2 = func(e2, o2)
+        res2.gm(S=0)
+
+        print(res1, res2)
+        print((res1.dvalue - res2.dvalue) / res1.dvalue)
+
+        assert np.isclose(res1.dvalue, res2.dvalue, rtol=0.01)

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -878,7 +878,7 @@ def test_correlation_intersection_of_idls():
     cov1 = pe.covariance([obs1, obs2_a])
     corr1 = pe.covariance([obs1, obs2_a], correlation=True)
 
-    obs2_b = obs2_a + pe.Obs([np.random.normal(1.0, 0.1, len(range2))], ["ens"], idl=[range2])
+    obs2_b = (obs2_a + pe.Obs([np.random.normal(1.0, 0.1, len(range2))], ["ens"], idl=[range2])) / 2
     obs2_b.gamma_method()
 
     cov2 = pe.covariance([obs1, obs2_b])

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -1066,6 +1066,7 @@ def test_overlapping_missing_cnfgs():
 
     t2 = o1 + a2
     t2.gm(S=0)
+    assert np.isclose(t1.value, t2.value)
     assert np.isclose(t1.dvalue, t2.dvalue, rtol=0.01)
 
 
@@ -1083,6 +1084,7 @@ def test_non_overlapping_missing_cnfgs():
 
     average = (even + odd) / 2
     average.gm(S=0)
+    assert np.isclose(full.value, average.value)
     assert np.isclose(full.dvalue, average.dvalue, rtol=0.01)
 
 
@@ -1112,6 +1114,7 @@ def test_non_overlapping_operations():
         print(res1, res2)
         print((res1.dvalue - res2.dvalue) / res1.dvalue)
 
+        assert np.isclose(res1.value, res2.value)
         assert np.isclose(res1.dvalue, res2.dvalue, rtol=0.01)
 
 
@@ -1141,4 +1144,5 @@ def test_non_overlapping_operations_different_lengths():
         res2 = func(f2, f2)
         res2.gm(S=0)
 
+        assert np.isclose(res1.value, res2.value)
         assert np.isclose(res1.dvalue, res2.dvalue, rtol=0.01)

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -1113,3 +1113,32 @@ def test_non_overlapping_operations():
         print((res1.dvalue - res2.dvalue) / res1.dvalue)
 
         assert np.isclose(res1.dvalue, res2.dvalue, rtol=0.01)
+
+
+def test_non_overlapping_operations_different_lengths():
+    length = 100000
+
+    samples = np.random.normal(0.93, 0.5, length)
+    first = samples[:length // 5]
+    second = samples[length // 5:]
+
+    f1 = pe.Obs([first], ["ensemble"], idl=[range(1, length // 5 + 1)])
+    s1 = pe.Obs([second], ["ensemble"], idl=[range(length // 5, length)])
+
+
+    f2 = pe.Obs([first], ["first"])
+    s2 = pe.Obs([second], ["second"])
+
+    for func in  [lambda a, b: a + b,
+                  lambda a, b: a - b,
+                  lambda a, b: a * b,
+                  lambda a, b: a / b,
+                  lambda a, b: a ** b,
+                  lambda a, b: a ** 2 + b ** 2 / a]:
+
+        res1 = func(f1, f1)
+        res1.gm(S=0)
+        res2 = func(f2, f2)
+        res2.gm(S=0)
+
+        assert np.isclose(res1.dvalue, res2.dvalue, rtol=0.01)

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -566,7 +566,7 @@ def test_intersection_reduce():
     intersection = pe.obs._intersection_idx([o.idl["ens"] for o in [obs1, obs_merge]])
     coll = pe.obs._reduce_deltas(obs_merge.deltas["ens"], obs_merge.idl["ens"], range1)
 
-    assert np.all(coll == obs1.deltas["ens"])
+    assert np.allclose(coll, obs1.deltas["ens"] * (len(obs_merge.idl["ens"]) / len(range1)))
 
 
 def test_irregular_error_propagation():


### PR DESCRIPTION
Fixes a critical bug that in some cases underestimated the error when different `idl`s for the same ensemble were used.