### PR TITLE
feat: removed computation of drho from standard windowing procedure.

### DIFF
--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -292,8 +292,8 @@ class Obs:
                 tmp = self.e_rho[e_name][i + 1:w_max] + np.concatenate([self.e_rho[e_name][i - 1::-1], self.e_rho[e_name][1:w_max - 2 * i]]) - 2 * self.e_rho[e_name][i] * self.e_rho[e_name][1:w_max - i]
                 self.e_drho[e_name][i] = np.sqrt(np.sum(tmp ** 2) / e_N)
 
-            _compute_drho(gapsize)
             if self.tau_exp[e_name] > 0:
+                _compute_drho(gapsize)
                 texp = self.tau_exp[e_name]
                 # Critical slowing down analysis
                 if w_max // 2 <= 1:
@@ -321,9 +321,8 @@ class Obs:
                     tau = self.S[e_name] / np.log((2 * self.e_n_tauint[e_name][gapsize::gapsize] + 1) / (2 * self.e_n_tauint[e_name][gapsize::gapsize] - 1))
                     g_w = np.exp(- np.arange(1, len(tau) + 1) / tau) - tau / np.sqrt(np.arange(1, len(tau) + 1) * e_N)
                     for n in range(1, w_max):
-                        if n < w_max // 2 - 2:
-                            _compute_drho(gapsize * n + gapsize)
                         if g_w[n - 1] < 0 or n >= w_max - 1:
+                            _compute_drho(gapsize * n)
                             n *= gapsize
                             self.e_tauint[e_name] = self.e_n_tauint[e_name][n] * (1 + (2 * n / gapsize + 1) / e_N) / (1 + 1 / e_N)  # Bias correction hep-lat/0306017 eq. (49)
                             self.e_dtauint[e_name] = self.e_n_dtauint[e_name][n]


### PR DESCRIPTION
I recently looked at simulations where I have access to more than a million samples and noticed that the standard windowing procedure can become very slow because most of the time is spent computing the error of rho which is not needed for the windowing but only when visualizing rho as a function of the window. For this reason I propose to remove the computation of drho for the standard windowing procedure. On my machine in a test setup with 5 million samples and $\tau_\mathrm{int}\approx 150$ the gamma method took 20.4s with the previous version and 820ms after the change.

The only downside that I can see is that the error of rho is not available for every data point when calling the `plot_rho` method. I attached how the output of this method looks like with the changes I propose.

![image](https://user-images.githubusercontent.com/22637881/217810086-dd594e0f-e0cc-4cd3-80af-8c479d61c486.png)

