### PR TITLE
_calculate_drho for large time separations

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -21,6 +21,6 @@ jobs:
       - name: flake8 Lint
         uses: py-actions/flake8@v2
         with:
-          ignore: "E501,E121,E123,E126,E226,E24,E704,W503,W504"
+          ignore: "E501,W503"
           exclude: "__init__.py, input/__init__.py"
           path: "pyerrors"

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -21,6 +21,6 @@ jobs:
       - name: flake8 Lint
         uses: py-actions/flake8@v2
         with:
-          ignore: "E501"
+          ignore: "E501,E121,E123,E126,E226,E24,E704,W503,W504"
           exclude: "__init__.py, input/__init__.py"
           path: "pyerrors"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,6 @@ pytest --cov=pyerrors --cov-report html
 ```
 The linter `flake8` is executed with the command
 ```
-flake8 --ignore=E501 --exclude=__init__.py pyerrors
+flake8 --extend-ignore=E501 --exclude=__init__.py pyerrors
 ```
 Please make sure that all tests are passed for a new pull requests.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,6 @@ pytest --cov=pyerrors --cov-report html
 ```
 The linter `flake8` is executed with the command
 ```
-flake8 --extend-ignore=E501 --exclude=__init__.py pyerrors
+flake8 --ignore=E501,W503 --exclude=__init__.py pyerrors
 ```
 Please make sure that all tests are passed for a new pull requests.

--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -289,7 +289,9 @@ class Obs:
             self.e_n_dtauint[e_name][0] = 0.0
 
             def _compute_drho(i):
-                tmp = self.e_rho[e_name][i + 1:w_max] + np.concatenate([self.e_rho[e_name][i - 1::-1], self.e_rho[e_name][1:w_max - 2 * i]]) - 2 * self.e_rho[e_name][i] * self.e_rho[e_name][1:w_max - i]
+                tmp = (self.e_rho[e_name][i + 1:w_max]
+                       + np.concatenate([self.e_rho[e_name][i - 1:None if i - w_max // 2 < 0 else 2 * (i - w_max // 2):-1], self.e_rho[e_name][1:max(1, w_max - 2 * i)]])
+                       - 2 * self.e_rho[e_name][i] * self.e_rho[e_name][1:w_max - i])
                 self.e_drho[e_name][i] = np.sqrt(np.sum(tmp ** 2) / e_N)
 
             if self.tau_exp[e_name] > 0:

--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -323,8 +323,8 @@ class Obs:
                     # Standard automatic windowing procedure
                     tau = self.S[e_name] / np.log((2 * self.e_n_tauint[e_name][gapsize::gapsize] + 1) / (2 * self.e_n_tauint[e_name][gapsize::gapsize] - 1))
                     g_w = np.exp(- np.arange(1, len(tau) + 1) / tau) - tau / np.sqrt(np.arange(1, len(tau) + 1) * e_N)
-                    for n in range(1, w_max):
-                        if g_w[n - 1] < 0 or n >= w_max - 1:
+                    for n in range(1, w_max // gapsize):
+                        if g_w[n - 1] < 0 or n >= w_max // gapsize - 1:
                             _compute_drho(gapsize * n)
                             n *= gapsize
                             self.e_tauint[e_name] = self.e_n_tauint[e_name][n] * (1 + (2 * n / gapsize + 1) / e_N) / (1 + 1 / e_N)  # Bias correction hep-lat/0306017 eq. (49)

--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -290,7 +290,8 @@ class Obs:
 
             def _compute_drho(i):
                 tmp = (self.e_rho[e_name][i + 1:w_max]
-                       + np.concatenate([self.e_rho[e_name][i - 1:None if i - w_max // 2 < 0 else 2 * (i - w_max // 2):-1], self.e_rho[e_name][1:max(1, w_max - 2 * i)]])
+                       + np.concatenate([self.e_rho[e_name][i - 1:None if i - w_max // 2 < 0 else 2 * (i - w_max // 2):-1],
+                                         self.e_rho[e_name][1:max(1, w_max - 2 * i)]])
                        - 2 * self.e_rho[e_name][i] * self.e_rho[e_name][1:w_max - i])
                 self.e_drho[e_name][i] = np.sqrt(np.sum(tmp ** 2) / e_N)
 

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -1152,3 +1152,7 @@ def test_nan_obs():
     o = pe.pseudo_Obs(1, .1, 'test')
     no = np.nan * o
     no.gamma_method()
+
+    o.idl['test'] = [1, 5] + list(range(7, 2002, 2))
+    no = np.NaN * o
+    no.gamma_method()

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -1146,3 +1146,9 @@ def test_non_overlapping_operations_different_lengths():
 
         assert np.isclose(res1.value, res2.value)
         assert np.isclose(res1.dvalue, res2.dvalue, rtol=0.01)
+
+
+def test_nan_obs():
+    o = pe.pseudo_Obs(1, .1, 'test')
+    no = np.nan * o
+    no.gamma_method()


### PR DESCRIPTION
This PR fixes `_compute_drho` for `i>w_max // 2` and closes #156. Irrespective of this we should maybe think about how the `gamma_method` should deal with observables that have values like `nan` and `inf`.