### PR TITLE
Serialize list of Obs in pandas.to_sql

### DIFF
--- a/pyerrors/input/pandas.py
+++ b/pyerrors/input/pandas.py
@@ -172,5 +172,8 @@ def _deserialize_df(df, auto_gamma=False):
             if '"program":' in df[column][0][:20]:
                 df[column] = df[column].transform(lambda x: import_json_string(x, verbose=False))
                 if auto_gamma is True:
-                    df[column].apply(lambda x: x.gamma_method())
+                    if isinstance(df[column][0], list):
+                        df[column].apply(lambda x: [o.gm() for o in x])
+                    else:
+                        df[column].apply(lambda x: x.gamma_method())
     return df

--- a/pyerrors/input/pandas.py
+++ b/pyerrors/input/pandas.py
@@ -135,7 +135,14 @@ def _serialize_df(df, gz=False):
     """
     out = df.copy()
     for column in out:
+        serialize = False
         if isinstance(out[column][0], (Obs, Corr)):
+            serialize = True
+        elif isinstance(out[column][0], list):
+            if all(isinstance(o, Obs) for o in out[column][0]):
+                serialize = True
+
+        if serialize is True:
             out[column] = out[column].transform(lambda x: create_json_string(x, indent=0))
             if gz is True:
                 out[column] = out[column].transform(lambda x: gzip.compress(x.encode('utf-8')))

--- a/tests/pandas_test.py
+++ b/tests/pandas_test.py
@@ -72,3 +72,15 @@ def test_sql_if_exists_fail(tmp_path):
         pe.input.pandas.to_sql(pe_df, "My_table", my_db)
     pe.input.pandas.to_sql(pe_df, "My_table", my_db, if_exists='append')
     pe.input.pandas.to_sql(pe_df, "My_table", my_db, if_exists='replace')
+
+
+def test_Obs_list_sql(tmp_path):
+    my_dict = {"int": 1,
+           "Obs1": pe.pseudo_Obs(17, 11, "test_sql_if_exists_failnsemble"),
+           "Obs_list": [[pe.pseudo_Obs(0.0, 0.1, "test_ensemble2"), pe.pseudo_Obs(3.2, 1.1, "test_ensemble2")]]}
+    pe_df = pd.DataFrame(my_dict)
+    my_db = (tmp_path / "test_db.sqlite").as_posix()
+    pe.input.pandas.to_sql(pe_df, "My_table", my_db)
+    for auto_gamma in [False, True]:
+        re_df = pe.input.pandas.read_sql("SELECT * from My_table", my_db, auto_gamma=auto_gamma)
+        assert np.all(re_df == pe_df)


### PR DESCRIPTION
I added the option to serialize lists of `Obs` when writing a pandas DataFrame to an sql database.