### PR TITLE
Feat/str format

### DIFF
--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -707,8 +707,9 @@ class Obs:
         return _format_uncertainty(self.value, self._dvalue)
 
     def __format__(self, format_type):
-        my_str = self.__str__()
-        if format_type in ["+", "-"]:
+        my_str = _format_uncertainty(self.value, self._dvalue,
+                                     significance=int(float(format_type.replace("+", "").replace("-", ""))))
+        if format_type.startswith(("+", "-")):
             if my_str[0] != "-":
                 my_str = " " + my_str
         return my_str

--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -706,6 +706,13 @@ class Obs:
     def __str__(self):
         return _format_uncertainty(self.value, self._dvalue)
 
+    def __format__(self, format_type):
+        my_str = self.__str__()
+        if format_type in ["+", "-"]:
+            if my_str[0] != "-":
+                my_str = " " + my_str
+        return my_str
+
     def __hash__(self):
         hash_tuple = (np.array([self.value]).astype(np.float32).data.tobytes(),)
         hash_tuple += tuple([o.astype(np.float32).data.tobytes() for o in self.deltas.values()])
@@ -980,17 +987,21 @@ class CObs:
         return 'CObs[' + str(self) + ']'
 
 
-def _format_uncertainty(value, dvalue):
+def _format_uncertainty(value, dvalue, significance=2):
     """Creates a string of a value and its error in paranthesis notation, e.g., 13.02(45)"""
     if dvalue == 0.0:
         return str(value)
+    if not isinstance(significance, int):
+        raise TypeError("significance needs to be an integer.")
+    if significance < 1:
+        raise ValueError("significance needs to be larger than zero.")
     fexp = np.floor(np.log10(dvalue))
     if fexp < 0.0:
-        return '{:{form}}({:2.0f})'.format(value, dvalue * 10 ** (-fexp + 1), form='.' + str(-int(fexp) + 1) + 'f')
+        return '{:{form}}({:1.0f})'.format(value, dvalue * 10 ** (-fexp + significance - 1), form='.' + str(-int(fexp) + significance - 1) + 'f')
     elif fexp == 0.0:
-        return '{:.1f}({:1.1f})'.format(value, dvalue)
+        return f"{value:.{significance - 1}f}({dvalue:1.{significance - 1}f})"
     else:
-        return '{:.0f}({:2.0f})'.format(value, dvalue)
+        return f"{value:.{max(0, int(significance - fexp - 1))}f}({dvalue:2.{max(0, int(significance - fexp - 1))}f})"
 
 
 def _expand_deltas(deltas, idx, shape):

--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -711,7 +711,7 @@ class Obs:
                                      significance=int(float(format_type.replace("+", "").replace("-", ""))))
         if format_type.startswith(("+", "-")):
             if my_str[0] != "-":
-                my_str = " " + my_str
+                my_str = "+" + my_str
         return my_str
 
     def __hash__(self):

--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -709,7 +709,7 @@ class Obs:
     def __format__(self, format_type):
         my_str = _format_uncertainty(self.value, self._dvalue,
                                      significance=int(float(format_type.replace("+", "").replace("-", ""))))
-        if format_type.startswith(("+", "-")):
+        if format_type.startswith("+"):
             if my_str[0] != "-":
                 my_str = "+" + my_str
         return my_str

--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -709,9 +709,10 @@ class Obs:
     def __format__(self, format_type):
         my_str = _format_uncertainty(self.value, self._dvalue,
                                      significance=int(float(format_type.replace("+", "").replace("-", ""))))
-        if format_type.startswith("+"):
-            if my_str[0] != "-":
-                my_str = "+" + my_str
+        for char in ["+", " "]:
+            if format_type.startswith(char):
+                if my_str[0] != "-":
+                    my_str = char + my_str
         return my_str
 
     def __hash__(self):

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -1167,5 +1167,5 @@ def test_format_uncertainty():
 
 def test_format():
     o1 = pe.pseudo_Obs(0.348, 0.0123, "test")
-    assert o1.__format__("+3") == ' 0.3480(123)'
-    assert o1.__format__("-2") == ' 0.348(12)'
+    assert o1.__format__("+3") == '+0.3480(123)'
+    assert o1.__format__("-2") == '+0.348(12)'

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -1169,3 +1169,4 @@ def test_format():
     o1 = pe.pseudo_Obs(0.348, 0.0123, "test")
     assert o1.__format__("+3") == '+0.3480(123)'
     assert o1.__format__("+2") == '+0.348(12)'
+    assert o1.__format__(" 2") == ' 0.348(12)'

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -1168,4 +1168,4 @@ def test_format_uncertainty():
 def test_format():
     o1 = pe.pseudo_Obs(0.348, 0.0123, "test")
     assert o1.__format__("+3") == '+0.3480(123)'
-    assert o1.__format__("-2") == '+0.348(12)'
+    assert o1.__format__("+2") == '+0.348(12)'

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -1163,3 +1163,9 @@ def test_format_uncertainty():
     assert pe.obs._format_uncertainty(0.548, 2.48497, 2) == '0.5(2.5)'
     assert pe.obs._format_uncertainty(0.548, 2.48497, 4) == '0.548(2.485)'
     assert pe.obs._format_uncertainty(0.548, 20078.3, 9) == '0.5480(20078.3000)'
+
+
+def test_format():
+    o1 = pe.pseudo_Obs(0.348, 0.0123, "test")
+    assert o1.__format__("+3") == ' 0.3480(123)'
+    assert o1.__format__("-2") == ' 0.348(12)'

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -1156,3 +1156,10 @@ def test_nan_obs():
     o.idl['test'] = [1, 5] + list(range(7, 2002, 2))
     no = np.NaN * o
     no.gamma_method()
+
+
+def test_format_uncertainty():
+    assert pe.obs._format_uncertainty(0.548, 0.248976, 4) == '0.5480(2490)'
+    assert pe.obs._format_uncertainty(0.548, 2.48497, 2) == '0.5(2.5)'
+    assert pe.obs._format_uncertainty(0.548, 2.48497, 4) == '0.548(2.485)'
+    assert pe.obs._format_uncertainty(0.548, 20078.3, 9) == '0.5480(20078.3000)'


### PR DESCRIPTION
This PR adds a `__format__` method to the `Obs` class and extends the functionality of `_format_uncertainty`.
For example the following code
```python
o0 = pe.pseudo_Obs(-0.3, 0.421, "test")
o1 = pe.pseudo_Obs(0.21, 0.1452879, "test")
for i, o in enumerate([o0, o1]):
    print(f"Obs{i} {o:+3}")
```
now outputs three significant digits and adds a + sign to non-negative observables:
```bash
Obs0 -0.300(421)
Obs1 +0.210(145)
```