### PR TITLE
fix: String conversion of Obs can now handle a dvalue that is NaN or inf

### DIFF
--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -978,7 +978,7 @@ class CObs:
 
 def _format_uncertainty(value, dvalue, significance=2):
     """Creates a string of a value and its error in paranthesis notation, e.g., 13.02(45)"""
-    if dvalue == 0.0:
+    if dvalue == 0.0 or (not np.isfinite(dvalue)):
         return str(value)
     if not isinstance(significance, int):
         raise TypeError("significance needs to be an integer.")

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -1254,7 +1254,9 @@ def test_format_uncertainty():
     assert pe.obs._format_uncertainty(0.548, 2.48497, 2) == '0.5(2.5)'
     assert pe.obs._format_uncertainty(0.548, 2.48497, 4) == '0.548(2.485)'
     assert pe.obs._format_uncertainty(0.548, 20078.3, 9) == '0.5480(20078.3000)'
-
+    pe.obs._format_uncertainty(np.NaN, 1)
+    pe.obs._format_uncertainty(1, np.NaN)
+    pe.obs._format_uncertainty(np.NaN, np.inf)
 
 def test_format():
     o1 = pe.pseudo_Obs(0.348, 0.0123, "test")


### PR DESCRIPTION
Calling 
```python
pe.obs._format_uncertainty(1, np.NaN)
```
led to an error because the case where dvalue is `nan` or `inf` has not been handled. This pr fixes this issue.