### PR TITLE
Fix/sort names

### DIFF
--- a/pyerrors/input/utils.py
+++ b/pyerrors/input/utils.py
@@ -18,18 +18,21 @@ def sort_names(ll):
         sorted list
     """
     if len(ll) > 1:
+        sorted = False
         r_pattern = r'r(\d+)'
         id_pattern = r'id(\d+)'
 
         # sort list by id first
         if all([re.search(id_pattern, entry) for entry in ll]):
             ll.sort(key=lambda x: int(re.findall(id_pattern, x)[0]))
+            sorted = True
         # then by replikum
         if all([re.search(r_pattern, entry) for entry in ll]):
             ll.sort(key=lambda x: int(re.findall(r_pattern, x)[0]))
+            sorted = True
         # as the rearrangements by one key let the other key untouched, the list is sorted now
 
-        else:
+        if not sorted:
             # fallback
             sames = ''
             for i in range(len(ll[0])):

--- a/pyerrors/input/utils.py
+++ b/pyerrors/input/utils.py
@@ -32,16 +32,15 @@ def sort_names(ll):
         else:
             # fallback
             sames = ''
-            if len(ll) > 1:
-                for i in range(len(ll[0])):
-                    checking = ll[0][i]
-                    for rn in ll[1:]:
-                        is_same = (rn[i] == checking)
-                    if is_same:
-                        sames += checking
-                    else:
-                        break
-                print("Using prefix:", ll[0][len(sames):])
+            for i in range(len(ll[0])):
+                checking = ll[0][i]
+                for rn in ll[1:]:
+                    is_same = (rn[i] == checking)
+                if is_same:
+                    sames += checking
+                else:
+                    break
+            print("Using prefix:", sames)
             ll.sort(key=lambda x: int(re.findall(r'\d+', x[len(sames):])[0]))
     return ll
 

--- a/tests/utils_in_test.py
+++ b/tests/utils_in_test.py
@@ -7,3 +7,26 @@ def test_sort_names():
 
     sorted_list = pe.input.utils.sort_names(my_list)
     assert (all([sorted_list[i] == presorted_list[i] for i in range(len(sorted_list))]))
+
+
+def test_sort_names_only_ids():
+    my_list = ['sfcf_T_id2', 'sfcf_T_id1', 'sfcf_T_id0', 'sfcf_T_id6', 'sfcf_T_id5']
+    presorted_list = ['sfcf_T_id0', 'sfcf_T_id1', 'sfcf_T_id2', 'sfcf_T_id5', 'sfcf_T_id6']
+
+    sorted_list = pe.input.utils.sort_names(my_list)
+    assert (all([sorted_list[i] == presorted_list[i] for i in range(len(sorted_list))]))
+
+
+def test_sort_names_only_reps():
+    my_list = ['sfcf_T_r2', 'sfcf_T_r1', 'sfcf_T_r0', 'sfcf_T_r6', 'sfcf_T_r5']
+    presorted_list = ['sfcf_T_r0', 'sfcf_T_r1', 'sfcf_T_r2', 'sfcf_T_r5', 'sfcf_T_r6']
+
+    sorted_list = pe.input.utils.sort_names(my_list)
+    assert (all([sorted_list[i] == presorted_list[i] for i in range(len(sorted_list))]))
+
+def test_sort_names_fallback():
+    my_list = ['xql2', 'xql1', 'xql0', 'xql6', 'xql5']
+    presorted_list = ['xql0', 'xql1', 'xql2', 'xql5', 'xql6']
+
+    sorted_list = pe.input.utils.sort_names(my_list)
+    assert (all([sorted_list[i] == presorted_list[i] for i in range(len(sorted_list))]))


### PR DESCRIPTION
Hi,
I found two small bugs in sort_names:
One is of cosmetic nature, the other one happened if only id was given as a sort pattern.
In that case, the method would subsequently use the fallback method.
While this did not harm the entire thing, it made some unneccessary work, so I corrected that and added tests for all cases.