### PR TITLE
Feat/files idl xsf

### DIFF
--- a/pyerrors/input/openQCD.py
+++ b/pyerrors/input/openQCD.py
@@ -1257,7 +1257,8 @@ def read_ms5_xsf(path, prefix, qc, corr, sep="r", **kwargs):
             for t in range(tmax):
                 realsamples[repnum].append([])
                 imagsamples[repnum].append([])
-
+            if 'idl' in kwargs:
+                left_idl = set(expected_idl[repnum])
             while True:
                 cnfgt = fp.read(chunksize)
                 if not cnfgt:
@@ -1267,6 +1268,7 @@ def read_ms5_xsf(path, prefix, qc, corr, sep="r", **kwargs):
                 idl_wanted = True
                 if 'idl' in kwargs:
                     idl_wanted = (cnfg in expected_idl[repnum])
+                    left_idl = left_idl - set([cnfg])
                 if idl_wanted:
                     cnfgs[repnum].append(cnfg)
 
@@ -1282,12 +1284,14 @@ def read_ms5_xsf(path, prefix, qc, corr, sep="r", **kwargs):
                         realsamples[repnum][t].append(corrres[0][t])
                     for t in range(int(len(tmpcorr) / 2)):
                         imagsamples[repnum][t].append(corrres[1][t])
+            if 'idl' in kwargs:
+                left_idl = list(left_idl)
+                if len(left_idl) > 0:
+                    warnings.warn('Could not find idls ' + str(left_idl) + ' in replikum of file ' + file, UserWarning)
         repnum += 1
-
-    s = "Read correlator " + corr + " from " + str(repnum) + " replika with " + str(len(realsamples[0][t]))
+    s = "Read correlator " + corr + " from " + str(repnum) + " replika with idls" + str(realsamples[0][t])
     for rep in range(1, repnum):
-        s += ", " + str(len(realsamples[rep][t]))
-    s += " samples"
+        s += ", " + str(realsamples[rep][t])
     print(s)
     print("Asserted run parameters:\n T:", tmax, "kappa:", kappa, "csw:", csw, "dF:", dF, "zF:", zF, "bnd:", bnd)
 

--- a/tests/openQCD_in_test.py
+++ b/tests/openQCD_in_test.py
@@ -121,7 +121,7 @@ def test_gf_coupling():
 
 
 def test_read_ms5_xsf():
-    path = './tests//data/openqcd_test/'
+    path = './tests/data/openqcd_test/'
     prefix = "ms5_xsf_T24L16"
     corr = "gA"
     qc = 'dd'
@@ -143,6 +143,37 @@ def test_read_ms5_xsf():
     fcorr = "gX"
     with pytest.raises(Exception):
         pe.input.openQCD.read_ms5_xsf(path, prefix, qc, fcorr)
+
+
+def test_read_ms5_xsf_idl():
+    path = './tests/data/openqcd_test/'
+    prefix = "ms5_xsf_T24L16"
+    corr = "gA"
+    qc = 'dd'
+
+    c = pe.input.openQCD.read_ms5_xsf(path, prefix, qc, corr, idl=[range(1, 6), range(1, 7), range(1, 8)])
+
+    assert c.real[12].names == ['ms5_xsf_T24L16|r1', 'ms5_xsf_T24L16|r2', 'ms5_xsf_T24L16|r3']
+
+    assert (c.real[12].shape['ms5_xsf_T24L16|r1'] == 5)
+    assert (c.real[12].shape['ms5_xsf_T24L16|r2'] == 6)
+    assert (c.real[12].shape['ms5_xsf_T24L16|r3'] == 7)
+
+    assert (c.real[12].idl['ms5_xsf_T24L16|r1'] == range(1, 6))
+    assert (c.real[12].idl['ms5_xsf_T24L16|r2'] == range(1, 7))
+    assert (c.real[12].idl['ms5_xsf_T24L16|r3'] == range(1, 8))
+
+    c = pe.input.openQCD.read_ms5_xsf(path, prefix, qc, corr, idl=[range(1, 11, 2), range(1, 11, 2), range(1, 11, 2)])
+
+    assert c.real[12].names == ['ms5_xsf_T24L16|r1', 'ms5_xsf_T24L16|r2', 'ms5_xsf_T24L16|r3']
+
+    assert (c.real[12].shape['ms5_xsf_T24L16|r1'] == 5)
+    assert (c.real[12].shape['ms5_xsf_T24L16|r2'] == 5)
+    assert (c.real[12].shape['ms5_xsf_T24L16|r3'] == 5)
+
+    assert (c.real[12].idl['ms5_xsf_T24L16|r1'] == range(1, 11, 2))
+    assert (c.real[12].idl['ms5_xsf_T24L16|r2'] == range(1, 11, 2))
+    assert (c.real[12].idl['ms5_xsf_T24L16|r3'] == range(1, 11, 2))
 
 
 def test_find_files():


### PR DESCRIPTION
Hi,
I made small changes to the xsf read method. Like this, the user can specify a range of idls that are to be read from each replikum file. This could be useful e.g. for crosschecks with other methods.
If the "expected" (meaning user-given) idls are not found in a file, a warning is thrown.
I also added another test for this case.