### PR TITLE
Conversion of an array with ndim > 0 to a scalar deprecation fixed

### DIFF
--- a/pyerrors/covobs.py
+++ b/pyerrors/covobs.py
@@ -42,7 +42,7 @@ class Covobs:
     def errsq(self):
         """ Return the variance (= square of the error) of the Covobs
         """
-        return float(np.dot(np.transpose(self.grad), np.dot(self.cov, self.grad)))
+        return np.dot(np.transpose(self.grad), np.dot(self.cov, self.grad)).item()
 
     def _set_cov(self, cov):
         """ Set the covariance matrix of the covobs

--- a/pyerrors/input/dobs.py
+++ b/pyerrors/input/dobs.py
@@ -850,7 +850,7 @@ def create_dobs_string(obsl, name, spec='dobs v1.0', origin='', symbol=[], who=N
             for i in range(ncov):
                 for o in obsl:
                     if cname in o.covobs:
-                        val = o.covobs[cname].grad[i]
+                        val = o.covobs[cname].grad[i].item()
                         if val != 0:
                             ds += '%1.14e ' % (val)
                         else:

--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -1521,7 +1521,7 @@ def _covariance_element(obs1, obs2):
         if e_name not in obs2.cov_names:
             continue
 
-        dvalue += float(np.dot(np.transpose(obs1.covobs[e_name].grad), np.dot(obs1.covobs[e_name].cov, obs2.covobs[e_name].grad)))
+        dvalue += np.dot(np.transpose(obs1.covobs[e_name].grad), np.dot(obs1.covobs[e_name].cov, obs2.covobs[e_name].grad)).item()
 
     return dvalue
 


### PR DESCRIPTION
With the upcoming release of numpy 1.25 we are hitting a few deprecations. This a fix for

>Only ndim-0 arrays are treated as scalars. NumPy used to treat all
arrays of size 1 (e.g., np.array([3.14])) as scalars. In the
future, this will be limited to arrays of ndim 0 (e.g.,
np.array(3.14)).

Please check that this does not break anything.
