### PR TITLE
Adjusted maximal value for rho in test_gamma_method_irregular.

### DIFF
--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -762,7 +762,7 @@ def test_gamma_method_irregular():
     N = 15
     for i in range(10):
         arr = np.random.normal(1, .2, size=N)
-        for rho in .1 * np.arange(20):
+        for rho in .05 * np.arange(20):
             carr = gen_autocorrelated_array(arr, rho)
             a = pe.Obs([carr], ['a'])
             a.gm()


### PR DESCRIPTION
PR #172 introduced a warning in the tests as `rho` can become larger than one which results in the computation of the square root of a negative number. I adjusted the maximal value for `rho` to 1.