### PR TITLE
Bug fix for edge case in _compute_drho

### DIFF
--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -278,7 +278,7 @@ class Obs:
 
             def _compute_drho(i):
                 tmp = (self.e_rho[e_name][i + 1:w_max]
-                       + np.concatenate([self.e_rho[e_name][i - 1:None if i - w_max // 2 <= 0 else 2 * (i - w_max // 2):-1],
+                       + np.concatenate([self.e_rho[e_name][i - 1:None if i - w_max // 2 <= 0 else (2 * i - (2 * w_max) // 2):-1],
                                          self.e_rho[e_name][1:max(1, w_max - 2 * i)]])
                        - 2 * self.e_rho[e_name][i] * self.e_rho[e_name][1:w_max - i])
                 self.e_drho[e_name][i] = np.sqrt(np.sum(tmp ** 2) / e_N)

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -767,6 +767,17 @@ def test_gamma_method_irregular():
             a = pe.Obs([carr], ['a'])
             a.gm()
 
+    arr = np.random.normal(1, .2, size=999)
+    carr = gen_autocorrelated_array(arr, .8)
+    o = pe.Obs([carr], ['test'])
+    o.gamma_method()
+    no = np.NaN * o
+    no.gamma_method()
+    o.idl['test'] = range(1, 1998, 2)
+    o.gamma_method()
+    no = np.NaN * o
+    no.gamma_method()
+
 
 def test_irregular_gapped_dtauint():
     my_idl = list(range(0, 5010, 10))


### PR DESCRIPTION
I finally got the indexing in the `_compute_drho` routine correct. My last fix did not solve all the edge cases that one can find and in one case, I ran into an error because the code tried to add arrays of non-equal size. I am fairly sure that the counting is now correct.