### PR TITLE
Fix Obs in f-strings without specifier

### DIFF
--- a/pyerrors/covobs.py
+++ b/pyerrors/covobs.py
@@ -42,7 +42,7 @@ class Covobs:
     def errsq(self):
         """ Return the variance (= square of the error) of the Covobs
         """
-        return float(np.dot(np.transpose(self.grad), np.dot(self.cov, self.grad)))
+        return np.dot(np.transpose(self.grad), np.dot(self.cov, self.grad)).item()
 
     def _set_cov(self, cov):
         """ Set the covariance matrix of the covobs

--- a/pyerrors/input/dobs.py
+++ b/pyerrors/input/dobs.py
@@ -850,7 +850,7 @@ def create_dobs_string(obsl, name, spec='dobs v1.0', origin='', symbol=[], who=N
             for i in range(ncov):
                 for o in obsl:
                     if cname in o.covobs:
-                        val = o.covobs[cname].grad[i]
+                        val = o.covobs[cname].grad[i].item()
                         if val != 0:
                             ds += '%1.14e ' % (val)
                         else:

--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -694,8 +694,12 @@ class Obs:
         return _format_uncertainty(self.value, self._dvalue)
 
     def __format__(self, format_type):
+        if format_type == "":
+            significance = 2
+        else:
+            significance = int(float(format_type.replace("+", "").replace("-", "")))
         my_str = _format_uncertainty(self.value, self._dvalue,
-                                     significance=int(float(format_type.replace("+", "").replace("-", ""))))
+                                     significance=significance)
         for char in ["+", " "]:
             if format_type.startswith(char):
                 if my_str[0] != "-":

--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -1521,7 +1521,7 @@ def _covariance_element(obs1, obs2):
         if e_name not in obs2.cov_names:
             continue
 
-        dvalue += float(np.dot(np.transpose(obs1.covobs[e_name].grad), np.dot(obs1.covobs[e_name].cov, obs2.covobs[e_name].grad)))
+        dvalue += np.dot(np.transpose(obs1.covobs[e_name].grad), np.dot(obs1.covobs[e_name].cov, obs2.covobs[e_name].grad)).item()
 
     return dvalue
 

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -1263,3 +1263,11 @@ def test_format():
     assert o1.__format__("+3") == '+0.3480(123)'
     assert o1.__format__("+2") == '+0.348(12)'
     assert o1.__format__(" 2") == ' 0.348(12)'
+
+def test_f_string_obs():
+    o1 = pe.pseudo_Obs(0.348, 0.0123, "test")
+    print(f"{o1}")
+    print(f"{o1:3}")
+    print(f"{o1:+3}")
+    print(f"{o1:-1}")
+    print(f"{o1: 8}")

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -1096,7 +1096,7 @@ def test_reduce_deltas():
     for idx_new in idl:
         new = pe.obs._reduce_deltas(deltas, idx_old, idx_new)
         print(new)
-        assert(np.alltrue([float(i) for i in idx_new] == new))
+        assert(np.all([float(i) for i in idx_new] == new))
 
 
 def test_cobs_array():


### PR DESCRIPTION
I introduced a bug in #170 which caused `Obs` in f-strings without a specifier to throw an error

```python
obs = pe.pseudo_Obs(1, 0.1, "test")
print(f"obs={obs}")
```

This PR fixes this bug.