### PR TITLE
Guards added for functionality that breaks with numpy>=1.25 and autograd==1.5

### DIFF
--- a/examples/05_matrix_operations.ipynb
+++ b/examples/05_matrix_operations.ipynb
@@ -344,7 +344,7 @@
     }
    ],
    "source": [
-    "if version.parse(np.__version__) >= version.parse("1.25.0"):\n",
+    "if version.parse(np.__version__) < version.parse(\"1.25.0\"):\n",
     "    e, v = pe.linalg.eigh(matrix)\n",
     "    for (i), entry in np.ndenumerate(e):\n",
     "        entry.gamma_method()\n",
@@ -380,7 +380,7 @@
     }
    ],
    "source": [
-    "if version.parse(np.__version__) >= version.parse("1.25.0"):\n",
+    "if version.parse(np.__version__) < version.parse(\"1.25.0\"):\n",
     "    for i in range(2):\n",
     "        print('Check eigenvector', i + 1)\n",
     "        print(matrix @ v[:, i] - v[:, i] * e[i])"

--- a/examples/05_matrix_operations.ipynb
+++ b/examples/05_matrix_operations.ipynb
@@ -6,6 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from packaging import version\n",
     "import pyerrors as pe\n",
     "import numpy as np\n",
     "import scipy"
@@ -343,15 +344,16 @@
     }
    ],
    "source": [
-    "e, v = pe.linalg.eigh(matrix)\n",
-    "for (i), entry in np.ndenumerate(e):\n",
-    "    entry.gamma_method()\n",
-    "print('Eigenvalues:')\n",
-    "print(e)\n",
-    "for (i, j), entry in np.ndenumerate(v):\n",
-    "    entry.gamma_method()\n",
-    "print('Eigenvectors:')\n",
-    "print(v)"
+    "if version.parse(np.__version__) >= version.parse("1.25.0"):\n",
+    "    e, v = pe.linalg.eigh(matrix)\n",
+    "    for (i), entry in np.ndenumerate(e):\n",
+    "        entry.gamma_method()\n",
+    "    print('Eigenvalues:')\n",
+    "    print(e)\n",
+    "    for (i, j), entry in np.ndenumerate(v):\n",
+    "        entry.gamma_method()\n",
+    "    print('Eigenvectors:')\n",
+    "    print(v)"
    ]
   },
   {
@@ -378,9 +380,10 @@
     }
    ],
    "source": [
-    "for i in range(2):\n",
-    "    print('Check eigenvector', i + 1)\n",
-    "    print(matrix @ v[:, i] - v[:, i] * e[i])"
+    "if version.parse(np.__version__) >= version.parse("1.25.0"):\n",
+    "    for i in range(2):\n",
+    "        print('Check eigenvector', i + 1)\n",
+    "        print(matrix @ v[:, i] - v[:, i] * e[i])"
    ]
   },
   {

--- a/pyerrors/linalg.py
+++ b/pyerrors/linalg.py
@@ -270,6 +270,8 @@ def eigh(obs, **kwargs):
 
 def eig(obs, **kwargs):
     """Computes the eigenvalues of a given matrix of Obs according to np.linalg.eig."""
+    if version.parse(np.__version__) >= version.parse("1.25.0"):
+        raise  NotImplementedError("eig error propagation is not working with numpy>=1.25 and autograd==1.5.")
     w = derived_observable(lambda x, **kwargs: anp.real(anp.linalg.eig(x)[0]), obs)
     return w
 

--- a/pyerrors/linalg.py
+++ b/pyerrors/linalg.py
@@ -1,3 +1,4 @@
+from packaging import version
 import numpy as np
 import autograd.numpy as anp  # Thinly-wrapped numpy
 from .obs import derived_observable, CObs, Obs, import_jackknife
@@ -260,6 +261,8 @@ def _mat_mat_op(op, obs, **kwargs):
 
 def eigh(obs, **kwargs):
     """Computes the eigenvalues and eigenvectors of a given hermitian matrix of Obs according to np.linalg.eigh."""
+    if version.parse(np.__version__) >= version.parse("1.25.0"):
+        raise  NotImplementedError("eigh error propagation is not working with numpy>=1.25 and autograd==1.5.")
     w = derived_observable(lambda x, **kwargs: anp.linalg.eigh(x)[0], obs)
     v = derived_observable(lambda x, **kwargs: anp.linalg.eigh(x)[1], obs)
     return w, v
@@ -278,6 +281,8 @@ def pinv(obs, **kwargs):
 
 def svd(obs, **kwargs):
     """Computes the singular value decomposition of a matrix of Obs."""
+    if version.parse(np.__version__) >= version.parse("1.25.0"):
+        raise  NotImplementedError("svd error propagation is not working with numpy>=1.25 and autograd==1.5.")
     u = derived_observable(lambda x, **kwargs: anp.linalg.svd(x, full_matrices=False)[0], obs)
     s = derived_observable(lambda x, **kwargs: anp.linalg.svd(x, full_matrices=False)[1], obs)
     vh = derived_observable(lambda x, **kwargs: anp.linalg.svd(x, full_matrices=False)[2], obs)

--- a/pyerrors/linalg.py
+++ b/pyerrors/linalg.py
@@ -262,7 +262,7 @@ def _mat_mat_op(op, obs, **kwargs):
 def eigh(obs, **kwargs):
     """Computes the eigenvalues and eigenvectors of a given hermitian matrix of Obs according to np.linalg.eigh."""
     if version.parse(np.__version__) >= version.parse("1.25.0"):
-        raise  NotImplementedError("eigh error propagation is not working with numpy>=1.25 and autograd==1.5.")
+        raise NotImplementedError("eigh error propagation is not working with numpy>=1.25 and autograd==1.5.")
     w = derived_observable(lambda x, **kwargs: anp.linalg.eigh(x)[0], obs)
     v = derived_observable(lambda x, **kwargs: anp.linalg.eigh(x)[1], obs)
     return w, v
@@ -271,7 +271,7 @@ def eigh(obs, **kwargs):
 def eig(obs, **kwargs):
     """Computes the eigenvalues of a given matrix of Obs according to np.linalg.eig."""
     if version.parse(np.__version__) >= version.parse("1.25.0"):
-        raise  NotImplementedError("eig error propagation is not working with numpy>=1.25 and autograd==1.5.")
+        raise NotImplementedError("eig error propagation is not working with numpy>=1.25 and autograd==1.5.")
     w = derived_observable(lambda x, **kwargs: anp.real(anp.linalg.eig(x)[0]), obs)
     return w
 
@@ -284,7 +284,7 @@ def pinv(obs, **kwargs):
 def svd(obs, **kwargs):
     """Computes the singular value decomposition of a matrix of Obs."""
     if version.parse(np.__version__) >= version.parse("1.25.0"):
-        raise  NotImplementedError("svd error propagation is not working with numpy>=1.25 and autograd==1.5.")
+        raise NotImplementedError("svd error propagation is not working with numpy>=1.25 and autograd==1.5.")
     u = derived_observable(lambda x, **kwargs: anp.linalg.svd(x, full_matrices=False)[0], obs)
     s = derived_observable(lambda x, **kwargs: anp.linalg.svd(x, full_matrices=False)[1], obs)
     vh = derived_observable(lambda x, **kwargs: anp.linalg.svd(x, full_matrices=False)[2], obs)

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -312,6 +312,13 @@ def test_matrix_functions():
 
         for (i, j), entry in np.ndenumerate(diff):
             assert entry.is_zero()
+    else:
+        with pytest.raises(NotImplementedError):
+            pe.linalg.eigh(sym)
+        with pytest.raises(NotImplementedError):
+            pe.linalg.eig(sym)
+        with pytest.raises(NotImplementedError):
+            pe.linalg.svd(sym)
 
     # Check determinant
     assert pe.linalg.det(np.diag(np.diag(matrix))) == np.prod(np.diag(matrix))

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -1,3 +1,4 @@
+from packaging import version
 import numpy as np
 import autograd.numpy as anp
 import math
@@ -291,23 +292,26 @@ def test_matrix_functions():
         diff = entry - sym[i, j]
         assert diff.is_zero()
 
-    # Check eigh
-    e, v = pe.linalg.eigh(sym)
-    for i in range(dim):
-        tmp = sym @ v[:, i] - v[:, i] * e[i]
-        for j in range(dim):
-            assert tmp[j].is_zero()
+    # These linalg functions don't work with numpy>=1.25 and autograd==1.5.
+    # Remove this guard once this is fixed in autograd.
+    if version.parse(np.__version__) < version.parse("1.25.0"):
+        # Check eigh
+        e, v = pe.linalg.eigh(sym)
+        for i in range(dim):
+            tmp = sym @ v[:, i] - v[:, i] * e[i]
+            for j in range(dim):
+                assert tmp[j].is_zero()
 
-    # Check eig function
-    e2 = pe.linalg.eig(sym)
-    assert np.all(np.sort(e) == np.sort(e2))
+        # Check eig function
+        e2 = pe.linalg.eig(sym)
+        assert np.all(np.sort(e) == np.sort(e2))
 
-    # Check svd
-    u, v, vh = pe.linalg.svd(sym)
-    diff = sym - u @ np.diag(v) @ vh
+        # Check svd
+        u, v, vh = pe.linalg.svd(sym)
+        diff = sym - u @ np.diag(v) @ vh
 
-    for (i, j), entry in np.ndenumerate(diff):
-        assert entry.is_zero()
+        for (i, j), entry in np.ndenumerate(diff):
+            assert entry.is_zero()
 
     # Check determinant
     assert pe.linalg.det(np.diag(np.diag(matrix))) == np.prod(np.diag(matrix))

--- a/tests/mpm_test.py
+++ b/tests/mpm_test.py
@@ -1,3 +1,4 @@
+from packaging import version
 import numpy as np
 import pyerrors as pe
 import pytest
@@ -5,10 +6,11 @@ import pytest
 np.random.seed(0)
 
 
-def test_mpm():
-    corr_content = []
-    for t in range(8):
-        f = 0.8 * np.exp(-0.4 * t)
-        corr_content.append(pe.pseudo_Obs(np.random.normal(f, 1e-2 * f), 1e-2 * f, 't'))
+if version.parse(np.__version__) < version.parse("1.25.0"):
+    def test_mpm():
+        corr_content = []
+        for t in range(8):
+            f = 0.8 * np.exp(-0.4 * t)
+            corr_content.append(pe.pseudo_Obs(np.random.normal(f, 1e-2 * f), 1e-2 * f, 't'))
 
-    res = pe.mpm.matrix_pencil_method(corr_content)
+        res = pe.mpm.matrix_pencil_method(corr_content)


### PR DESCRIPTION
This PR guards the methods and tests that break with the recent release of numpy 1.25 (see #191) and gives instructive error messages when trying to use the affected methods. Once the problem is solved this PR should be reverted.