### PR TITLE
Bootstrap export/import

### DIFF
--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -703,9 +703,9 @@ class Obs:
         numpy.ndarray
             Returns a numpy array of length N + 1 where N is the number of samples
             for the given ensemble and replicum. The zeroth entry of the array contains
-            the mean value of the Obs, entries 1 to N contain the N jackknife samples
+            the mean value of the Obs, entries 1 to N contain the N import_bootstrap samples
             derived from the Obs. The current implementation only works for observables
-            defined on exactly one ensemble and replicum. The derived jackknife samples
+            defined on exactly one ensemble and replicum. The derived bootstrap samples
             should agree with samples from a full bootstrap analysis up to O(1/N).
         """
         if len(self.names) != 1:
@@ -1605,7 +1605,9 @@ def import_bootstrap(boots, name, random_numbers):
     name : str
         name of the ensemble the samples are defined on.
     random_numbers : np.ndarray
-        Array of shape (samples, length) containing the random numbers to generate the bootstrap samples.
+        Array of shape (samples, length) containing the random numbers to generate the bootstrap samples,
+        where samples is the number of bootstrap samples and length is the length of the original Monte Carlo
+        chain to be reconstructed.
     """
     samples, length = random_numbers.shape
     if samples != len(boots) - 1:

--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -684,6 +684,49 @@ class Obs:
         tmp_jacks[1:] = (n * mean - full_data) / (n - 1)
         return tmp_jacks
 
+    def export_bootstrap(self, samples=500, random_numbers=None, save_rng=None):
+        """Export bootstrap samples from the Obs
+
+        Parameters
+        ----------
+        samples : int
+            Number of bootstrap samples to generate.
+        random_numbers : np.ndarray
+            Array of shape (samples, length) containing the random numbers to generate the bootstrap samples.
+            If not provided the bootstrap samples are generated bashed on the md5 hash of the enesmble name.
+        save_rng : str
+            Save the random numbers to a file if a path is specified.
+
+        Returns
+        -------
+        numpy.ndarray
+            Returns a numpy array of length N + 1 where N is the number of samples
+            for the given ensemble and replicum. The zeroth entry of the array contains
+            the mean value of the Obs, entries 1 to N contain the N jackknife samples
+            derived from the Obs. The current implementation only works for observables
+            defined on exactly one ensemble and replicum. The derived jackknife samples
+            should agree with samples from a full jackknife analysis up to O(1/N).
+        """
+        if len(self.names) != 1:
+            raise Exception("'export_boostrap' is only implemented for Obs defined on one ensemble and replicum.")
+
+        name = self.names[0]
+        length = self.N
+
+        if random_numbers is None:
+            seed = int(hashlib.md5(name.encode()).hexdigest(), 16) & 0xFFFFFFFF
+            rng = np.random.default_rng(seed)
+            random_numbers = rng.integers(0, length, size=(samples, length))
+
+        if save_rng is not None:
+            np.savetxt(save_rng, random_numbers, fmt='%i')
+
+        proj = np.vstack([np.bincount(o, minlength=length) for o in random_numbers]) / length
+        ret = np.zeros(samples + 1)
+        ret[0] = self.value
+        ret[1:] = proj @ (self.deltas[name] + self.r_values[name])
+        return ret
+
     def __float__(self):
         return float(self.value)
 

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -1094,6 +1094,15 @@ def test_import_jackknife():
     assert my_obs == reconstructed_obs
 
 
+def test_import_bootstrap():
+    name = "test"
+    samples = 1234
+    obs = pe.pseudo_Obs(2.447, 0.14, name)
+    boots = obs.export_bootstrap(1234)
+    re_obs = pe.import_bootstrap(boots, name, (1000, 1234))
+    assert obs == re_obs
+
+
 def test_reduce_deltas():
     idx_old = range(1, 101)
     deltas = [float(i) for i in idx_old]

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -1095,11 +1095,16 @@ def test_import_jackknife():
 
 
 def test_import_bootstrap():
-    name = "test"
+    seed = 4321
     samples = 1234
-    obs = pe.pseudo_Obs(2.447, 0.14, name)
-    boots = obs.export_bootstrap(1234)
-    re_obs = pe.import_bootstrap(boots, name, (1000, 1234))
+    length = 820
+    name = "test"
+
+    rng = np.random.default_rng(seed)
+    random_numbers = rng.integers(0, length, size=(samples, length))
+    obs = pe.pseudo_Obs(2.447, 0.14, name, length)
+    boots = obs.export_bootstrap(1234, random_numbers=random_numbers)
+    re_obs = pe.import_bootstrap(boots, name, random_numbers=random_numbers)
     assert obs == re_obs
 
 


### PR DESCRIPTION
I added the functionality to bootstrap resample an `Obs` with given random numbers or via random numbers generated from the ensemble name.

If the number of bootstrap samples is larger than the number of Monte Carlo samples the bootstrap samples can then be reimported into an `Obs`.