### PR TITLE
Matmul overloaded for correlator class.

### DIFF
--- a/pyerrors/correlators.py
+++ b/pyerrors/correlators.py
@@ -257,7 +257,7 @@ class Corr:
     def trace(self):
         """Calculates the per-timeslice trace of a correlator matrix."""
         if self.N == 1:
-            raise TypeError("Only works for correlator matrices.")
+            raise ValueError("Only works for correlator matrices.")
         newcontent = []
         for t in range(self.T):
             if _check_for_none(self, self.content[t]):

--- a/pyerrors/correlators.py
+++ b/pyerrors/correlators.py
@@ -255,6 +255,7 @@ class Corr:
         return True
 
     def trace(self):
+        """Calculates the per-timeslice trace of a correlator matrix."""
         if self.N == 1:
             raise TypeError("Only works for correlator matrices.")
         newcontent = []

--- a/pyerrors/correlators.py
+++ b/pyerrors/correlators.py
@@ -417,7 +417,7 @@ class Corr:
         dt : int
             number of timeslices
         """
-        return Corr(list(np.roll(np.array(self.content, dtype=object), dt)))
+        return Corr(list(np.roll(np.array(self.content, dtype=object), dt, axis=0)))
 
     def reverse(self):
         """Reverse the time ordering of the Corr"""

--- a/pyerrors/correlators.py
+++ b/pyerrors/correlators.py
@@ -220,7 +220,7 @@ class Corr:
     def anti_symmetric(self):
         """Anti-symmetrize the correlator around x0=0."""
         if self.N != 1:
-            raise Exception('anti_symmetric cannot be safely applied to multi-dimensional correlators.')
+            raise TypeError('anti_symmetric cannot be safely applied to multi-dimensional correlators.')
         if self.T % 2 != 0:
             raise Exception("Can not symmetrize odd T")
 
@@ -242,7 +242,7 @@ class Corr:
     def is_matrix_symmetric(self):
         """Checks whether a correlator matrices is symmetric on every timeslice."""
         if self.N == 1:
-            raise Exception("Only works for correlator matrices.")
+            raise TypeError("Only works for correlator matrices.")
         for t in range(self.T):
             if self[t] is None:
                 continue
@@ -253,6 +253,17 @@ class Corr:
                     if hash(self[t][i, j]) != hash(self[t][j, i]):
                         return False
         return True
+
+    def trace(self):
+        if self.N == 1:
+            raise TypeError("Only works for correlator matrices.")
+        newcontent = []
+        for t in range(self.T):
+            if _check_for_none(self, self.content[t]):
+                newcontent.append(None)
+            else:
+                newcontent.append(np.trace(self.content[t]))
+        return Corr(newcontent)
 
     def matrix_symmetric(self):
         """Symmetrizes the correlator matrices on every timeslice."""
@@ -1080,8 +1091,10 @@ class Corr:
 
     def __matmul__(self, y):
         if isinstance(y, np.ndarray):
+            if y.ndim != 2 or y.shape[0] != y.shape[1]:
+                raise ValueError("Can only multiply correlators by square matrices.")
             if not self.N == y.shape[0]:
-                raise TypeError("Shape mismatch")
+                raise ValueError("matmul: mismatch of matrix dimensions")
             newcontent = []
             for t in range(self.T):
                 if _check_for_none(self, self.content[t]):
@@ -1089,8 +1102,19 @@ class Corr:
                 else:
                     newcontent.append(self.content[t] @ y)
             return Corr(newcontent)
+        elif isinstance(y, Corr):
+            if not self.N == y.N:
+                raise ValueError("matmul: mismatch of matrix dimensions")
+            newcontent = []
+            for t in range(self.T):
+                if _check_for_none(self, self.content[t]) or _check_for_none(y, y.content[t]):
+                    newcontent.append(None)
+                else:
+                    newcontent.append(self.content[t] @ y.content[t])
+            return Corr(newcontent)
+
         else:
-            raise NotImplementedError("Matmul not implemented for this type.")
+            raise TypeError("Matmul not implemented for this type.")
 
     def __truediv__(self, y):
         if isinstance(y, Corr):

--- a/pyerrors/correlators.py
+++ b/pyerrors/correlators.py
@@ -1078,6 +1078,20 @@ class Corr:
         else:
             raise TypeError("Corr * wrong type")
 
+    def __matmul__(self, y):
+        if isinstance(y, np.ndarray):
+            if not self.N == y.shape[0]:
+                raise TypeError("Shape mismatch")
+            newcontent = []
+            for t in range(self.T):
+                if _check_for_none(self, self.content[t]):
+                    newcontent.append(None)
+                else:
+                    newcontent.append(self.content[t] @ y)
+            return Corr(newcontent)
+        else:
+            raise NotImplementedError("Matmul not implemented for this type.")
+
     def __truediv__(self, y):
         if isinstance(y, Corr):
             if not ((self.N == 1 or y.N == 1 or self.N == y.N) and self.T == y.T):

--- a/tests/correlators_test.py
+++ b/tests/correlators_test.py
@@ -628,6 +628,12 @@ def test_matmul_overloading():
     for i in range(4):
         assert np.all(tt[i] == 0)
 
+    # associative property
+    tt = (corr.real @ pe.dirac.gammaX + corr.imag @ (pe.dirac.gammaX * 1j)) - corr @ pe.dirac.gammaX
+    for el in tt:
+        if el is not None:
+            assert np.all(el == 0)
+
     corr2 = corr @ corr
     for i in range(4):
         np.all(corr2[i] == corr[i] @ corr[i])

--- a/tests/correlators_test.py
+++ b/tests/correlators_test.py
@@ -608,12 +608,17 @@ def test_matmul_overloading():
     mat = np.array(ll).reshape(N, N)
 
     # Multiply with gamma matrix
-    mat @ pe.dirac.gammaX
     corr = pe.Corr([mat] * 4, padding=[0, 1])
-    pe.dirac.gammaX @ corr
-    mcorr = corr @ pe.dirac.gammaX
 
+    # __matmul__
+    mcorr = corr @ pe.dirac.gammaX
     comp = mat @ pe.dirac.gammaX
+    for i in range(4):
+        assert np.all(mcorr[i] == comp)
+
+    # __rmatmul__
+    mcorr = pe.dirac.gammaX @ corr
+    comp = pe.dirac.gammaX @ mat
     for i in range(4):
         assert np.all(mcorr[i] == comp)
 

--- a/tests/correlators_test.py
+++ b/tests/correlators_test.py
@@ -668,6 +668,10 @@ def test_matrix_trace():
         assert el == 0
 
 
+    with pytest.raises(ValueError):
+        corr.item(0, 0).trace()
+
+
 def test_corr_roll():
     T = 4
     rn = lambda : np.random.normal(0.5, 0.1)

--- a/tests/correlators_test.py
+++ b/tests/correlators_test.py
@@ -610,6 +610,7 @@ def test_matmul_overloading():
     # Multiply with gamma matrix
     mat @ pe.dirac.gammaX
     corr = pe.Corr([mat] * 4, padding=[0, 1])
+    pe.dirac.gammaX @ corr
     mcorr = corr @ pe.dirac.gammaX
 
     comp = mat @ pe.dirac.gammaX
@@ -645,9 +646,12 @@ def test_matrix_trace():
     for el in corr.trace():
         el == np.sum(np.diag(mat))
 
+    # Trace is cyclic
+    for one, two in zip((pe.dirac.gammaX @ corr).trace(), (corr @ pe.dirac.gammaX).trace()):
+        assert np.all(one == two)
+
     # Antisymmetric matrices are traceless.
     mat = (mat - mat.T) / 2
-
     corr = pe.Corr([mat] * 4)
     for el in corr.trace():
         assert el == 0

--- a/tests/correlators_test.py
+++ b/tests/correlators_test.py
@@ -666,3 +666,25 @@ def test_matrix_trace():
     corr = pe.Corr([mat] * 4)
     for el in corr.trace():
         assert el == 0
+
+
+def test_corr_roll():
+    T = 4
+    rn = lambda : np.random.normal(0.5, 0.1)
+
+    ll = []
+    for i in range(T):
+        re = pe.pseudo_Obs(rn(), rn(), "test")
+        im = pe.pseudo_Obs(rn(), rn(), "test")
+        ll.append(pe.CObs(re, im))
+
+    # Rolling by T should produce the same correlator
+    corr = pe.Corr(ll)
+    tt = corr - corr.roll(T)
+    for el in tt:
+        assert np.all(el == 0)
+
+    mcorr = pe.Corr(np.array([[corr, corr + 0.1], [corr - 0.1, 2 * corr]]))
+    tt = mcorr.roll(T) - mcorr
+    for el in tt:
+        assert np.all(el == 0)

--- a/tests/correlators_test.py
+++ b/tests/correlators_test.py
@@ -570,3 +570,84 @@ def test_corr_symmetric():
         assert scorr[1] == scorr[3]
         assert scorr[2] == corr[2]
         assert scorr[0] == corr[0]
+
+
+def test_two_matrix_corr_inits():
+    T = 4
+    rn = lambda : np.random.normal(0.5, 0.1)
+
+    # Generate T random CObs in a list
+    list_of_timeslices =[]
+    for i in range(T):
+        re = pe.pseudo_Obs(rn(), rn(), "test")
+        im = pe.pseudo_Obs(rn(), rn(), "test")
+        list_of_timeslices.append(pe.CObs(re, im))
+
+    # First option: Correlator of matrix of correlators
+    corr = pe.Corr(list_of_timeslices)
+    mat_corr1 = pe.Corr(np.array([[corr, corr], [corr, corr]]))
+
+    # Second option: Correlator of list of arrays per timeslice
+    list_of_arrays = [np.array([[elem, elem], [elem, elem]]) for elem in list_of_timeslices]
+    mat_corr2 = pe.Corr(list_of_arrays)
+
+    for el in mat_corr1 - mat_corr2:
+        assert np.all(el == 0)
+
+
+def test_matmul_overloading():
+    N = 4
+    rn = lambda : np.random.normal(0.5, 0.1)
+
+    # Generate N^2 random CObs and assemble them in an array
+    ll =[]
+    for i in range(N ** 2):
+        re = pe.pseudo_Obs(rn(), rn(), "test")
+        im = pe.pseudo_Obs(rn(), rn(), "test")
+        ll.append(pe.CObs(re, im))
+    mat = np.array(ll).reshape(N, N)
+
+    # Multiply with gamma matrix
+    mat @ pe.dirac.gammaX
+    corr = pe.Corr([mat] * 4, padding=[0, 1])
+    mcorr = corr @ pe.dirac.gammaX
+
+    comp = mat @ pe.dirac.gammaX
+    for i in range(4):
+        assert np.all(mcorr[i] == comp)
+
+    test_mat = pe.dirac.gamma5 + pe.dirac.gammaX
+    icorr = corr @ test_mat @ np.linalg.inv(test_mat)
+    tt = corr - icorr
+    for i in range(4):
+        assert np.all(tt[i] == 0)
+
+    corr2 = corr @ corr
+    for i in range(4):
+        np.all(corr2[i] == corr[i] @ corr[i])
+
+
+def test_matrix_trace():
+    N = 4
+    rn = lambda : np.random.normal(0.5, 0.1)
+
+    # Generate N^2 random CObs and assemble them in an array
+    ll =[]
+    for i in range(N ** 2):
+        re = pe.pseudo_Obs(rn(), rn(), "test")
+        im = pe.pseudo_Obs(rn(), rn(), "test")
+        ll.append(pe.CObs(re, im))
+    mat = np.array(ll).reshape(N, N)
+
+    corr = pe.Corr([mat] * 4)
+
+    # Explicitly check trace
+    for el in corr.trace():
+        el == np.sum(np.diag(mat))
+
+    # Antisymmetric matrices are traceless.
+    mat = (mat - mat.T) / 2
+
+    corr = pe.Corr([mat] * 4)
+    for el in corr.trace():
+        assert el == 0

--- a/tests/fits_test.py
+++ b/tests/fits_test.py
@@ -235,12 +235,12 @@ def test_fit_corr_independent():
 
 
 def test_linear_fit_guesses():
-    for err in [10, 0.1, 0.001]:
+    for err in [1.2, 0.1, 0.001]:
         xvals = []
         yvals = []
         for x in range(1, 8, 2):
             xvals.append(x)
-            yvals.append(pe.pseudo_Obs(x + np.random.normal(0.0, err), err, 'test1') + pe.pseudo_Obs(0, err / 100, 'test2', samples=87))
+            yvals.append(pe.pseudo_Obs(x + np.random.normal(0.0, err), err, 'test1') + pe.pseudo_Obs(0, err / 97, 'test2', samples=87))
         lin_func = lambda a, x: a[0] + a[1] * x
         with pytest.raises(Exception):
             pe.least_squares(xvals, yvals, lin_func)
@@ -251,7 +251,7 @@ def test_linear_fit_guesses():
         bad_guess = pe.least_squares(xvals, yvals, lin_func, initial_guess=[999, 999])
         good_guess = pe.least_squares(xvals, yvals, lin_func, initial_guess=[0, 1])
         assert np.isclose(bad_guess.chisquare, good_guess.chisquare, atol=1e-8)
-        assert np.all([(go - ba).is_zero(atol=1e-6) for (go, ba) in zip(good_guess, bad_guess)])
+        assert np.all([(go - ba).is_zero(atol=5e-5) for (go, ba) in zip(good_guess, bad_guess)])
 
 
 def test_total_least_squares():


### PR DESCRIPTION
I overloaded the matmul class which should now allow for the multiplication of matrix valued `Corr` objects with matrices. I will write a few tests and look into edge cases but this solution seems to work.