### PR TITLE
CObs format added and complex Corr print improved.

### DIFF
--- a/pyerrors/correlators.py
+++ b/pyerrors/correlators.py
@@ -998,8 +998,6 @@ class Corr:
             content_string += "Description: " + self.tag + "\n"
         if self.N != 1:
             return content_string
-        if isinstance(self[0], CObs):
-            return content_string
 
         if print_range[1]:
             print_range[1] += 1
@@ -1010,7 +1008,7 @@ class Corr:
             else:
                 content_string += str(i + print_range[0])
                 for element in sub_corr:
-                    content_string += '\t' + ' ' * int(element >= 0) + str(element)
+                    content_string += f"\t{element:+2}"
                 content_string += '\n'
         return content_string
 

--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -979,6 +979,14 @@ class CObs:
     def __repr__(self):
         return 'CObs[' + str(self) + ']'
 
+    def __format__(self, format_type):
+        if format_type == "":
+            significance = 2
+            format_type = "2"
+        else:
+            significance = int(float(format_type.replace("+", "").replace("-", "")))
+        return f"({self.real:{format_type}}{self.imag:+{significance}}j)"
+
 
 def _format_uncertainty(value, dvalue, significance=2):
     """Creates a string of a value and its error in paranthesis notation, e.g., 13.02(45)"""

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -1283,6 +1283,16 @@ def test_f_string_obs():
     print(f"{o1:-1}")
     print(f"{o1: 8}")
 
+def test_f_string_cobs():
+    o_real = pe.pseudo_Obs(0.348, 0.0123, "test")
+    o_imag = pe.pseudo_Obs(0.348, 0.0123, "test")
+    o1 = pe.CObs(o_real, o_imag)
+    print(f"{o1}")
+    print(f"{o1:3}")
+    print(f"{o1:+3}")
+    print(f"{o1:-1}")
+    print(f"{o1: 8}")
+
 def test_compute_drho_fails():
     obs = pe.input.json.load_json("tests/data/compute_drho_fails.json.gz")
     obs.gm()


### PR DESCRIPTION
I worked a bit on the string conversion of complex observables and correlators.

- `CObs` now have a `__format__` method which allows for f-string formatting like this: 
```python
print(f"{my_cobs:+3}")
> (+0.018(465)+0.443(393)j)
```
- I use this to also improve the print output of complex correlators which now produces the following:
```python
Corr T=4 N=1
x0/a	Corr(x0/a)
------------------
0	(+0.02(46)+0.44(39)j)
1	(+0.00(59)+0.43(37)j)
2	(+0.01(58)+0.64(47)j)
3	(-0.03(62)+0.45(51)j)
```
 Please have a look @JanNeuendorf

PS: There is still no proper print output for matrix correlators.