### PR TITLE
Explicit Exception for combined fit edge case

### DIFF
--- a/pyerrors/fits.py
+++ b/pyerrors/fits.py
@@ -230,6 +230,12 @@ def least_squares(x, y, func, priors=None, silent=False, **kwargs):
         n_parms_ls.append(n_loc)
 
     n_parms = max(n_parms_ls)
+
+    if len(key_ls) > 1:
+        for key in key_ls:
+            if np.asarray(yd[key]).shape != funcd[key](np.arange(n_parms), xd[key]).shape:
+                raise ValueError(f"Fit function {key} returns the wrong shape ({funcd[key](np.arange(n_parms), xd[key]).shape} instead of {xd[key].shape})\nIf the fit function is just a constant you could try adding x*0 to get the correct shape.")
+
     if not silent:
         print('Fit with', n_parms, 'parameter' + 's' * (n_parms > 1))
 

--- a/tests/fits_test.py
+++ b/tests/fits_test.py
@@ -1143,6 +1143,23 @@ def test_fit_dof():
     assert np.all(np.array(cd[1:]) > 0)
 
 
+def test_combined_fit_constant_shape():
+    N1 = 16
+    N2 = 10
+    x = {"a": np.arange(N1),
+         "": np.arange(N2)}
+    y = {"a": [pe.pseudo_Obs(o + np.random.normal(0.0, 0.1), 0.1, "test") for o in range(N1)],
+         "": [pe.pseudo_Obs(o + np.random.normal(0.0, 0.1), 0.1, "test") for o in range(N2)]}
+    funcs = {"a": lambda a, x: a[0] + a[1] * x,
+             "": lambda a, x: a[1]}
+    with pytest.raises(ValueError):
+        pe.fits.least_squares(x, y, funcs, method='migrad')
+
+    funcs = {"a": lambda a, x: a[0] + a[1] * x,
+             "": lambda a, x: a[1] + x * 0}
+    pe.fits.least_squares(x, y, funcs, method='migrad')
+
+
 def fit_general(x, y, func, silent=False, **kwargs):
     """Performs a non-linear fit to y = func(x) and returns a list of Obs corresponding to the fit parameters.
 


### PR DESCRIPTION
This PR addresses an issue in combined fits that @PiaLJP had seen in the past and @matteo-dc ran into this week:
When doing a combined fit and one of the fit functions is just a constant then the shape casting fails and one gets an error. The solution we found in the past is to add `x * 0` to the constant in the fit function to obtain the correct shape.

This PR does not fix the issue as I wasn't able to come up with a good solution, yet. Instead, I added an explicit exception that informs the user and suggests our workaround. For the future, it would of course be desirable to correct the shape casting for this edge case.