### PR TITLE
Corr array initialization generalized

### DIFF
--- a/pyerrors/correlators.py
+++ b/pyerrors/correlators.py
@@ -21,6 +21,9 @@ class Corr:
     The correlator can have two types of content: An Obs at every timeslice OR a matrix at every timeslice.
     Other dependency (eg. spatial) are not supported.
 
+    The Corr class can also deal with missing measurements or paddings for fixed boundary conditions.
+    The missing entries are represented via the `None` object.
+
     Initialization
     --------------
     A simple correlator can be initialized with a list or a one-dimensional array of `Obs` or `Cobs`

--- a/pyerrors/correlators.py
+++ b/pyerrors/correlators.py
@@ -41,7 +41,7 @@ class Corr:
         """
 
         if isinstance(data_input, np.ndarray):
-            if data_input.ndim in (1, 3):
+            if data_input.ndim == 1:
                 data_input = list(data_input)
             elif data_input.ndim == 2:
                 if not data_input.shape[0] == data_input.shape[1]:
@@ -68,6 +68,10 @@ class Corr:
                                 array_at_timeslace[i, j] = data_input[i, j][t]
                         input_as_list.append(array_at_timeslace)
                 data_input = input_as_list
+            elif data_input.ndim == 3:
+                if not data_input.shape[1] == data_input.shape[2]:
+                    raise ValueError("Array needs to be square.")
+                data_input = list(data_input)
             else:
                 raise ValueError("Arrays with ndim>3 not supported.")
 

--- a/pyerrors/correlators.py
+++ b/pyerrors/correlators.py
@@ -32,7 +32,7 @@ class Corr:
     ```python
     matrix_corr = pe.Corr(np.array([[corr11, corr12], [corr21, corr22]]))
     ```
-    or alternativly via a three-dimensional array of `Obs` or `CObs` of shape (T, N, N) where T is
+    or alternatively via a three-dimensional array of `Obs` or `CObs` of shape (T, N, N) where T is
     the temporal extent of the correlator and N is the dimension of the matrix.
     """
 
@@ -51,7 +51,7 @@ class Corr:
             at the back.
         prange : list, optional
             List containing the first and last timeslice of the plateau
-            region indentified for this correlator.
+            region identified for this correlator.
         """
 
         if isinstance(data_input, np.ndarray):
@@ -519,7 +519,7 @@ class Corr:
         ----------
         partner : Corr
             Time symmetry partner of the Corr
-        partity : int
+        parity : int
             Parity quantum number of the correlator, can be +1 or -1
         """
         if self.N != 1:
@@ -677,8 +677,8 @@ class Corr:
         ----------
         variant : str
             log : uses the standard effective mass log(C(t) / C(t+1))
-            cosh, periodic : Use periodicitiy of the correlator by solving C(t) / C(t+1) = cosh(m * (t - T/2)) / cosh(m * (t + 1 - T/2)) for m.
-            sinh : Use anti-periodicitiy of the correlator by solving C(t) / C(t+1) = sinh(m * (t - T/2)) / sinh(m * (t + 1 - T/2)) for m.
+            cosh, periodic : Use periodicity of the correlator by solving C(t) / C(t+1) = cosh(m * (t - T/2)) / cosh(m * (t + 1 - T/2)) for m.
+            sinh : Use anti-periodicity of the correlator by solving C(t) / C(t+1) = sinh(m * (t - T/2)) / sinh(m * (t + 1 - T/2)) for m.
             See, e.g., arXiv:1205.5380
             arccosh : Uses the explicit form of the symmetrized correlator (not recommended)
             logsym: uses the symmetric effective mass log(C(t-1) / C(t+1))/2

--- a/pyerrors/correlators.py
+++ b/pyerrors/correlators.py
@@ -11,15 +11,29 @@ from .roots import find_root
 
 
 class Corr:
-    """The class for a correlator (time dependent sequence of pe.Obs).
+    r"""The class for a correlator (time dependent sequence of pe.Obs).
 
     Everything, this class does, can be achieved using lists or arrays of Obs.
     But it is simply more convenient to have a dedicated object for correlators.
     One often wants to add or multiply correlators of the same length at every timeslice and it is inconvenient
     to iterate over all timeslices for every operation. This is especially true, when dealing with matrices.
 
-    The correlator can have two types of content: An Obs at every timeslice OR a GEVP
-    matrix at every timeslice. Other dependency (eg. spatial) are not supported.
+    The correlator can have two types of content: An Obs at every timeslice OR a matrix at every timeslice.
+    Other dependency (eg. spatial) are not supported.
+
+    Initialization
+    --------------
+    A simple correlator can be initialized with a list or a one-dimensional array of `Obs` or `Cobs`
+    ```python
+    corr11 = pe.Corr([obs1, obs2])
+    corr11 = pe.Corr(np.array([obs1, obs2]))
+    ```
+    A matrix-valued correlator can either be initialized via a two-dimensional array of `Corr` objects
+    ```python
+    matrix_corr = pe.Corr(np.array([[corr11, corr12], [corr21, corr22]]))
+    ```
+    or alternativly via a three-dimensional array of `Obs` or `CObs` of shape (T, N, N) where T is
+    the temporal extent of the correlator and N is the dimension of the matrix.
     """
 
     __slots__ = ["content", "N", "T", "tag", "prange"]
@@ -30,7 +44,7 @@ class Corr:
         Parameters
         ----------
         data_input : list or array
-            list of Obs or list of arrays of Obs or array of Corrs
+            list of Obs or list of arrays of Obs or array of Corrs (see class docstring for details).
         padding : list, optional
             List with two entries where the first labels the padding
             at the front of the correlator and the second the padding

--- a/tests/correlators_test.py
+++ b/tests/correlators_test.py
@@ -570,3 +570,21 @@ def test_corr_symmetric():
         assert scorr[1] == scorr[3]
         assert scorr[2] == corr[2]
         assert scorr[0] == corr[0]
+
+
+def test_corr_array_ndim1_init():
+    y = [pe.pseudo_Obs(2 + np.random.normal(0.0, 0.1), .1, 't') for i in np.arange(5)]
+    cc1 = pe.Corr(y)
+    cc2 = pe.Corr(np.array(y))
+    assert np.all([o1 == o2 for o1, o2 in zip(cc1, cc2)])
+
+
+def test_corr_array_ndim3_init():
+    y = np.array([pe.pseudo_Obs(np.random.normal(2.0, 0.1), .1, 't') for i in np.arange(12)]).reshape(3, 2, 2)
+    tt1 = pe.Corr(list(y))
+    tt2 = pe.Corr(y)
+    tt3 = pe.Corr(np.array([pe.Corr(o) for o in y.reshape(3, 4).T]).reshape(2, 2))
+    assert np.all([o1 == o2 for o1, o2 in zip(tt1, tt2)])
+    assert np.all([o1 == o2 for o1, o2 in zip(tt1, tt3)])
+    assert tt1.T == y.shape[0]
+    assert tt1.N == y.shape[1] == y.shape[2]

--- a/tests/correlators_test.py
+++ b/tests/correlators_test.py
@@ -588,3 +588,6 @@ def test_corr_array_ndim3_init():
     assert np.all([o1 == o2 for o1, o2 in zip(tt1, tt3)])
     assert tt1.T == y.shape[0]
     assert tt1.N == y.shape[1] == y.shape[2]
+
+    with pytest.raises(ValueError):
+        pe.Corr(y.reshape(6, 2, 1))


### PR DESCRIPTION
I generalized the initialization of the `Corr` class. Correlators can now additionally be initialized with
- One-dimensional arrays (equivalent to a list)
- Three-dimensional arrays of shape (T, N, N)

I think I did not touch what happens to lists and two-dimensional arrays. Please have a close look.