### PR TITLE
Feat/read sfcf multi

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,5 @@
 /pyerrors/covobs.py @s-kuberski
 /pyerrors/input/json.py @s-kuberski
 /pyerrors/input/dobs.py @s-kuberski
+/pyerrors/input/sfcf.py @jkuhl-uni
+/tests/sfcf_in_test.py @jkuhl-uni

--- a/pyerrors/input/sfcf.py
+++ b/pyerrors/input/sfcf.py
@@ -75,7 +75,7 @@ def read_sfcf(path, prefix, name, quarks='.*', corr_type="bi", noffset=0, wf=0, 
     return ret[name][quarks][str(noffset)][str(wf)][str(wf2)]
 
 
-def read_sfcf_multi(path, prefix, name_list, quarks_list=['.*'], corr_type_list=['bi'],  noffset_list=[0], wf_list=[0], wf2_list=[0], version="1.0c", cfg_separator="n", silent=False, keyed_out=False, **kwargs):
+def read_sfcf_multi(path, prefix, name_list, quarks_list=['.*'], corr_type_list=['bi'], noffset_list=[0], wf_list=[0], wf2_list=[0], version="1.0c", cfg_separator="n", silent=False, keyed_out=False, **kwargs):
     """Read sfcf files from given folder structure.
 
     Parameters

--- a/pyerrors/input/sfcf.py
+++ b/pyerrors/input/sfcf.py
@@ -86,21 +86,21 @@ def read_sfcf_multi(path, prefix, name_list, quarks_list=['.*'], corr_type_list=
         Prefix of the sfcf files.
     name : str
         Name of the correlation function to read.
-    quarks : str
+    quarks_list : list[str]
         Label of the quarks used in the sfcf input file. e.g. "quark quark"
         for version 0.0 this does NOT need to be given with the typical " - "
         that is present in the output file,
         this is done automatically for this version
-    corr_type : str
+    corr_type_list : list[str]
         Type of correlation function to read. Can be
         - 'bi' for boundary-inner
         - 'bb' for boundary-boundary
         - 'bib' for boundary-inner-boundary
-    noffset : int
+    noffset_list : list[int]
         Offset of the source (only relevant when wavefunctions are used)
-    wf : int
+    wf_list : int
         ID of wave function
-    wf2 : int
+    wf2_list : list[int]
         ID of the second wavefunction
         (only relevant for boundary-to-boundary correlation functions)
     im : bool
@@ -130,9 +130,13 @@ def read_sfcf_multi(path, prefix, name_list, quarks_list=['.*'], corr_type_list=
 
     Returns
     -------
-    result: list[Obs]
-        list of Observables with length T, observable per timeslice.
-        bb-type correlators have length 1.
+    result: dict[list[Obs]]
+        dict with one of the following properties:
+        if keyed_out:
+            dict[key] = list[Obs]
+            where key has the form name/quarks/offset/wf/wf2
+        if not keyed_out:
+            dict[name][quarks][offset][wf][wf2] = list[Obs]
     """
 
     if kwargs.get('im'):

--- a/pyerrors/input/sfcf.py
+++ b/pyerrors/input/sfcf.py
@@ -6,7 +6,17 @@ from ..obs import Obs
 from .utils import sort_names, check_idl
 
 
-def read_sfcf(path, prefix, name, quarks='.*', corr_type='bi', noffset=0, wf=0, wf2=0, version="1.0c", cfg_separator="n", silent=False, **kwargs):
+_corr_type_dict = {
+    "f_A": "bi",
+    "g_A": "bi",
+    "f_P": "bi",
+    "g_P": "bi",
+    "f_1": "bb",
+    "k_1": "bb",
+}
+
+
+def read_sfcf(path, prefix, name, quarks='.*', corr_type = "bi" ,noffsets=0, wf1s=0, wf2s=0, version="1.0c", cfg_separator="n", silent=False, **kwargs):
     """Read sfcf files from given folder structure.
 
     Parameters
@@ -65,7 +75,70 @@ def read_sfcf(path, prefix, name, quarks='.*', corr_type='bi', noffset=0, wf=0, 
         list of Observables with length T, observable per timeslice.
         bb-type correlators have length 1.
     """
-    if kwargs.get('im'):
+
+    return read_sfcf_multi(path, prefix, [name], quark_pairs=[quarks], corr_type=[corr_type], noffset=[0], wf=[0], wf2=[0], version="1.0c", cfg_separator="n", silent=False, **kwargs)
+
+
+def read_sfcf_multi(path, prefix, names, quark_pairs='.*', corr_type=['bi'],  noffset=0, wf=0, wf2=0, version="1.0c", cfg_separator="n", silent=False, **kwargs):
+    """Read sfcf files from given folder structure.
+
+    Parameters
+    ----------
+    path : str
+        Path to the sfcf files.
+    prefix : str
+        Prefix of the sfcf files.
+    name : str
+        Name of the correlation function to read.
+    quarks : str
+        Label of the quarks used in the sfcf input file. e.g. "quark quark"
+        for version 0.0 this does NOT need to be given with the typical " - "
+        that is present in the output file,
+        this is done automatically for this version
+    corr_type : str
+        Type of correlation function to read. Can be
+        - 'bi' for boundary-inner
+        - 'bb' for boundary-boundary
+        - 'bib' for boundary-inner-boundary
+    noffset : int
+        Offset of the source (only relevant when wavefunctions are used)
+    wf : int
+        ID of wave function
+    wf2 : int
+        ID of the second wavefunction
+        (only relevant for boundary-to-boundary correlation functions)
+    im : bool
+        if True, read imaginary instead of real part
+        of the correlation function.
+    names : list
+        Alternative labeling for replicas/ensembles.
+        Has to have the appropriate length
+    ens_name : str
+        replaces the name of the ensemble
+    version: str
+        version of SFCF, with which the measurement was done.
+        if the compact output option (-c) was specified,
+        append a "c" to the version (e.g. "1.0c")
+        if the append output option (-a) was specified,
+        append an "a" to the version
+    cfg_separator : str
+        String that separates the ensemble identifier from the configuration number (default 'n').
+    replica: list
+        list of replica to be read, default is all
+    files: list
+        list of files to be read per replica, default is all.
+        for non-compact output format, hand the folders to be read here.
+    check_configs: list[list[int]]
+        list of list of supposed configs, eg. [range(1,1000)]
+        for one replicum with 1000 configs
+
+    Returns
+    -------
+    result: list[Obs]
+        list of Observables with length T, observable per timeslice.
+        bb-type correlators have length 1.
+    """
+    if kwargs.get('im') is True:
         im = 1
         part = 'imaginary'
     else:

--- a/pyerrors/input/sfcf.py
+++ b/pyerrors/input/sfcf.py
@@ -80,7 +80,7 @@ def read_sfcf(path, prefix, name, quarks='.*', corr_type="bi", noffset=0, wf1=0,
     return ret
 
 
-def read_sfcf_multi(path, prefix, name_list, quark_pairs=['.*'], corr_type=['bi'],  noffset_list=[0], wf1_list=[0], wf2_list=[0], version="1.0c", cfg_separator="n", silent=False, nice_output=False, **kwargs):
+def read_sfcf_multi(path, prefix, name_list, quark_pairs=['.*'], corr_type_list=['bi'],  noffset_list=[0], wf1_list=[0], wf2_list=[0], version="1.0c", cfg_separator="n", silent=False, nice_output=False, **kwargs):
     """Read sfcf files from given folder structure.
 
     Parameters
@@ -207,9 +207,9 @@ def read_sfcf_multi(path, prefix, name_list, quark_pairs=['.*'], corr_type=['bi'
     idl = []
 
     intern = {}
-    for name, c_type in zip(name_list, corr_type):
+    for name, corr_type in zip(name_list, corr_type_list):
         intern[name] = {}
-        b2b, single = _extract_corr_type(c_type)
+        b2b, single = _extract_corr_type(corr_type)
         intern[name]["b2b"] = b2b
         intern[name]["single"] = single
         intern[name]["spec"] = {}
@@ -323,7 +323,7 @@ def read_sfcf_multi(path, prefix, name_list, quark_pairs=['.*'], corr_type=['bi'
                                 rep_idl = []
                                 filename = path + '/' + file
                                 T, rep_idl, rep_data = _read_append_rep(filename, pattern, b2b, cfg_separator, im, single)
-                                if not 'T' in intern[name]:
+                                if 'T' not in intern[name]:
                                     intern[name]['T'] = T
                                 if rep == 0:
                                     for t in range(T):

--- a/pyerrors/input/sfcf.py
+++ b/pyerrors/input/sfcf.py
@@ -359,8 +359,6 @@ def read_sfcf_multi(path, prefix, name_list, quarks_list=['.*'], corr_type_list=
                         for t in range(intern[name]["T"]):
                             result.append(Obs(internal_ret_dict[name][quarks][str(off)][str(w)][str(w2)][t], new_names, idl=idl))
                         result_dict[name][quarks][str(off)][str(w)][str(w2)] = result
-    if nice_output:
-        result_dict = _reduce_dict(result_dict)
     return result_dict
 
 
@@ -632,13 +630,3 @@ def _get_appended_rep_names(ls, prefix, name, ens_name=None):
         else:
             new_names.append(myentry[:idx] + '|' + myentry[idx:])
     return new_names
-
-
-def _reduce_dict(d):
-    for key in d.keys():
-        if isinstance(d[key], dict):
-            ret = _reduce_dict(d[key])
-        else:
-            if len(list(d.keys())) == 1:
-                ret = d[list(d.keys())[0]]
-    return ret

--- a/pyerrors/input/sfcf.py
+++ b/pyerrors/input/sfcf.py
@@ -69,12 +69,11 @@ def read_sfcf(path, prefix, name, quarks='.*', corr_type="bi", noffset=0, wf=0, 
     """
     ret = read_sfcf_multi(path, prefix, [name], quarks_list=[quarks], corr_type_list=[corr_type],
                           noffset_list=[noffset], wf_list=[wf], wf2_list=[wf2], version=version,
-                          cfg_separator=cfg_separator, silent=silent, nice_output=True, **kwargs)
+                          cfg_separator=cfg_separator, silent=silent, **kwargs)
+    return ret[name][quarks][str(noffset)][str(wf)][str(wf2)]
 
-    return ret
 
-
-def read_sfcf_multi(path, prefix, name_list, quarks_list=['.*'], corr_type_list=['bi'],  noffset_list=[0], wf_list=[0], wf2_list=[0], version="1.0c", cfg_separator="n", silent=False, nice_output=False, **kwargs):
+def read_sfcf_multi(path, prefix, name_list, quarks_list=['.*'], corr_type_list=['bi'],  noffset_list=[0], wf_list=[0], wf2_list=[0], version="1.0c", cfg_separator="n", silent=False, **kwargs):
     """Read sfcf files from given folder structure.
 
     Parameters
@@ -331,8 +330,6 @@ def read_sfcf_multi(path, prefix, name_list, quarks_list=['.*'], corr_type_list=
             result.append(Obs(internal_ret_dict[k][t], new_names, idl=idl))
         print(result)
         result_dict[k] = result
-    if nice_output:
-        result_dict = _reduce_dict(result_dict)
     return result_dict
 
 
@@ -629,16 +626,6 @@ def _get_appended_rep_names(ls, prefix, name, ens_name=None):
         else:
             new_names.append(myentry[:idx] + '|' + myentry[idx:])
     return new_names
-
-
-def _reduce_dict(d):
-    for key in d.keys():
-        if isinstance(d[key], dict):
-            ret = _reduce_dict(d[key])
-        else:
-            if len(list(d.keys())) == 1:
-                ret = d[list(d.keys())[0]]
-    return ret
 
 
 def _get_deep_paths(f, sep='/'):

--- a/pyerrors/input/sfcf.py
+++ b/pyerrors/input/sfcf.py
@@ -371,7 +371,6 @@ def read_sfcf_multi(path, prefix, name_list, quarks_list=['.*'], corr_type_list=
 
 
 def _lists2key(*lists):
-    sep = "/"
     keys = []
     for tup in itertools.product(*lists):
         keys.append(sep.join(tup))

--- a/pyerrors/input/sfcf.py
+++ b/pyerrors/input/sfcf.py
@@ -4,6 +4,8 @@ import re
 import numpy as np  # Thinly-wrapped numpy
 from ..obs import Obs
 from .utils import sort_names, check_idl
+from benedict import benedict
+from copy import deepcopy
 
 
 def read_sfcf(path, prefix, name, quarks='.*', corr_type="bi", noffset=0, wf=0, wf2=0, version="1.0c", cfg_separator="n", silent=False, **kwargs):
@@ -65,7 +67,9 @@ def read_sfcf(path, prefix, name, quarks='.*', corr_type="bi", noffset=0, wf=0, 
         list of Observables with length T, observable per timeslice.
         bb-type correlators have length 1.
     """
-    ret = read_sfcf_multi(path, prefix, [name], quarks_list=[quarks], corr_type_list=[corr_type], noffset_list=[noffset], wf_list=[wf], wf2_list=[wf2], version=version, cfg_separator=cfg_separator, silent=silent, nice_output=True, **kwargs)
+    ret = read_sfcf_multi(path, prefix, [name], quarks_list=[quarks], corr_type_list=[corr_type],
+                          noffset_list=[noffset], wf_list=[wf], wf2_list=[wf2], version=version,
+                          cfg_separator=cfg_separator, silent=silent, nice_output=True, **kwargs)
 
     return ret
 
@@ -195,32 +199,11 @@ def read_sfcf_multi(path, prefix, name_list, quarks_list=['.*'], corr_type_list=
 
     idl = []
 
-    # setup dect structures
-    intern = {}
-    for name, corr_type in zip(name_list, corr_type_list):
-        intern[name] = {}
-        b2b, single = _extract_corr_type(corr_type)
-        intern[name]["b2b"] = b2b
-        intern[name]["single"] = single
-        intern[name]["spec"] = {}
-        for quarks in quarks_list:
-            intern[name]["spec"][quarks] = {}
-            for off in noffset_list:
-                intern[name]["spec"][quarks][str(off)] = {}
-                for w in wf_list:
-                    intern[name]["spec"][quarks][str(off)][str(w)] = {}
-                    for w2 in wf2_list:
-                        intern[name]["spec"][quarks][str(off)][str(w)][str(w2)] = {}
+    # setup dict structures
+    intern = _setup_intern_dict(name_list, corr_type_list, quarks_list, noffset_list, wf_list, wf2_list)
 
-    internal_ret_dict = {}
-    for name in name_list:
-        internal_ret_dict[name] = {}
-        for quarks in quarks_list:
-            internal_ret_dict[name][quarks] = {}
-            for off in noffset_list:
-                internal_ret_dict[name][quarks][str(off)] = {}
-                for w in wf_list:
-                    internal_ret_dict[name][quarks][str(off)][str(w)] = {}
+    ret_key_paths, internal_ret_dict = _setup_ret_dict(name_list, quarks_list, noffset_list, wf_list, wf2_list)
+    dict_template = deepcopy(internal_ret_dict)
 
     if not appended:
         for i, item in enumerate(ls):
@@ -249,60 +232,53 @@ def read_sfcf_multi(path, prefix, name_list, quarks_list=['.*'], corr_type_list=
             if i == 0:
                 if version != "0.0" and compact:
                     file = path + '/' + item + '/' + sub_ls[0]
-
-                for name in name_list:
+                for k in ret_key_paths:
+                    ori_keys = k.split("/")
+                    name = ori_keys[0]
+                    quarks = ori_keys[1]
+                    off = ori_keys[2]
+                    w = ori_keys[3]
+                    w2 = ori_keys[4]
                     if version == "0.0" or not compact:
                         file = path + '/' + item + '/' + sub_ls[0] + '/' + name
-                    for quarks in quarks_list:
-                        for off in noffset_list:
-                            for w in wf_list:
-                                for w2 in wf2_list:
-                                    # here, we want to find the place within the file,
-                                    # where the correlator we need is stored.
-                                    # to do so, the pattern needed is put together
-                                    # from the input values
-                                    intern[name]["spec"][quarks][str(off)][str(w)][str(w2)]["pattern"] = _make_pattern(version, name, off, w, w2, intern[name]['b2b'], quarks)
-                                    start_read, T = _find_correlator(file, version, intern[name]["spec"][quarks][str(off)][str(w)][str(w2)]["pattern"], intern[name]['b2b'], silent=silent)
-                                    intern[name]["spec"][quarks][str(off)][str(w)][str(w2)]["start"] = start_read
-                                    intern[name]["T"] = T
-                                    # preparing the datastructure
-                                    # the correlators get parsed into...
-                                    deltas = []
-                                    for j in range(intern[name]["T"]):
-                                        deltas.append([])
-                                    internal_ret_dict[name][quarks][str(off)][str(w)][str(w2)] = deltas
+                    # here, we want to find the place within the file,
+                    # where the correlator we need is stored.
+                    # to do so, the pattern needed is put together
+                    # from the input values
+                    intern[name]["spec"][quarks][str(off)][str(w)][str(w2)]["pattern"] = _make_pattern(version, name, off, w, w2, intern[name]['b2b'], quarks)
+                    start_read, T = _find_correlator(file, version, intern[name]["spec"][quarks][off][w][w2]["pattern"], intern[name]['b2b'], silent=silent)
+                    intern[name]["spec"][quarks][str(off)][str(w)][str(w2)]["start"] = start_read
+                    intern[name]["T"] = T
+                    # preparing the datastructure
+                    # the correlators get parsed into...
+                    deltas = []
+                    for j in range(intern[name]["T"]):
+                        deltas.append([])
+                    internal_ret_dict[k] = deltas
 
             if compact:
-                rep_deltas = _read_compact_rep(path, item, sub_ls, intern, im)
-                for name in name_list:
-                    for quarks in quarks_list:
-                        for off in noffset_list:
-                            for w in wf_list:
-                                for w2 in wf2_list:
-                                    for t in range(intern[name]["T"]):
-                                        internal_ret_dict[name][quarks][str(off)][str(w)][str(w2)][t].append(rep_deltas[name][quarks][str(off)][str(w)][str(w2)][t])
+                rep_deltas = _read_compact_rep(path, item, sub_ls, intern, ret_key_paths, im, dict_template)
+                for k in ret_key_paths:
+                    name = k.split("/")[0]
+                    for t in range(intern[name]["T"]):
+                        internal_ret_dict[k][t].append(rep_deltas[k][t])
             else:
-                for name in name_list:
+                for name in internal_ret_dict:
                     rep_data = []
                     for cnfg, subitem in enumerate(sub_ls):
-                        for quarks in quarks_list:
-                            for off in noffset_list:
-                                for w in wf_list:
-                                    for w2 in wf2_list:
-                                        cfg_path = path + '/' + item + '/' + subitem
-                                        file_data = _read_o_file(cfg_path, name, intern, version, im)
-                                        rep_data.append(file_data)
+                        for k in _get_deep_paths(internal_ret_dict.subset(name)):
+                            cfg_path = path + '/' + item + '/' + subitem
+                            file_data = _read_o_file(cfg_path, name, intern, version, im, dict_template)
+                            rep_data.append(file_data)
 
-                    for quarks in quarks_list:
-                        for off in noffset_list:
-                            for w in wf_list:
-                                for w2 in wf2_list:
-                                    for t in range(intern[name]["T"]):
-                                        internal_ret_dict[name][quarks][str(off)][str(w)][str(w2)][t].append([])
-                                        for cfg in range(no_cfg):
-                                            internal_ret_dict[name][quarks][str(off)][str(w)][str(w2)][t][i].append(rep_data[cfg][quarks][str(off)][str(w)][str(w2)][t])
+                    for k in _get_deep_paths(internal_ret_dict.subset(name)[name]):
+                        for t in range(intern[name]["T"]):
+                            internal_ret_dict[name][k][t].append([])
+                            for cfg in range(no_cfg):
+                                internal_ret_dict[name][k][t][i].append(rep_data[cfg][k][t])
     else:
-        for name in name_list:
+
+        for name in internal_ret_dict:
             if "files" in kwargs:
                 ls = kwargs.get("files")
             else:
@@ -310,26 +286,29 @@ def read_sfcf_multi(path, prefix, name_list, quarks_list=['.*'], corr_type_list=
                 for exc in name_ls:
                     if not fnmatch.fnmatch(exc, prefix + '*.' + name):
                         name_ls = list(set(name_ls) - set([exc]))
+
             name_ls = sort_names(name_ls)
-            for quarks in quarks_list:
-                for off in noffset_list:
-                    for w in wf_list:
-                        for w2 in wf2_list:
-                            pattern = _make_pattern(version, name, off, w, w2, intern[name]['b2b'], quarks)
-                            deltas = []
-                            for rep, file in enumerate(name_ls):
-                                rep_idl = []
-                                filename = path + '/' + file
-                                T, rep_idl, rep_data = _read_append_rep(filename, pattern, intern[name]['b2b'], cfg_separator, im, intern[name]['single'])
-                                if rep == 0:
-                                    intern[name]['T'] = T
-                                    for t in range(intern[name]['T']):
-                                        deltas.append([])
-                                for t in range(intern[name]['T']):
-                                    deltas[t].append(rep_data[t])
-                                internal_ret_dict[name][quarks][str(off)][str(w)][str(w2)] = deltas
-                                if name == name_list[0]:
-                                    idl.append(rep_idl)
+            for k in _get_deep_paths(internal_ret_dict.subset(name)[name]):
+                ori_keys = k.split("/")
+                quarks = ori_keys[0]
+                off = ori_keys[1]
+                w = ori_keys[2]
+                w2 = ori_keys[3]
+                pattern = _make_pattern(version, name, off, w, w2, intern[name]['b2b'], quarks)
+                deltas = []
+                for rep, file in enumerate(name_ls):
+                    rep_idl = []
+                    filename = path + '/' + file
+                    T, rep_idl, rep_data = _read_append_rep(filename, pattern, intern[name]['b2b'], cfg_separator, im, intern[name]['single'])
+                    if rep == 0:
+                        intern[name]['T'] = T
+                        for t in range(intern[name]['T']):
+                            deltas.append([])
+                    for t in range(intern[name]['T']):
+                        deltas[t].append(rep_data[t])
+                    internal_ret_dict[name][k] = deltas
+                    if name == name_list[0]:
+                        idl.append(rep_idl)
 
     if kwargs.get("check_configs") is True:
         if not silent:
@@ -344,47 +323,78 @@ def read_sfcf_multi(path, prefix, name_list, quarks_list=['.*'], corr_type_list=
         if not silent:
             print("Done")
 
-    result_dict = {}
-    for name in name_list:
-        result_dict[name] = {}
-        for quarks in quarks_list:
-            result_dict[name][quarks] = {}
-            for off in noffset_list:
-                result_dict[name][quarks][str(off)] = {}
-                for w in wf_list:
-                    result_dict[name][quarks][str(off)][str(w)] = {}
-                    for w2 in wf2_list:
-                        result = []
-                        for t in range(intern[name]["T"]):
-                            result.append(Obs(internal_ret_dict[name][quarks][str(off)][str(w)][str(w2)][t], new_names, idl=idl))
-                        result_dict[name][quarks][str(off)][str(w)][str(w2)] = result
+    result_dict = deepcopy(dict_template)
+    for k in ret_key_paths:
+        name = k.split("/")[0]
+        result = []
+        for t in range(intern[name]["T"]):
+            result.append(Obs(internal_ret_dict[k][t], new_names, idl=idl))
+        print(result)
+        result_dict[k] = result
     if nice_output:
         result_dict = _reduce_dict(result_dict)
     return result_dict
 
 
-def _read_o_file(cfg_path, name, intern, version, im):
+def _setup_ret_dict(name_list, quarks_list, noffset_list, wf_list, wf2_list):
+    internal_ret_dict = {}
+    for name in name_list:
+        internal_ret_dict[name] = {}
+        for quarks in quarks_list:
+            internal_ret_dict[name][quarks] = {}
+            for off in noffset_list:
+                internal_ret_dict[name][quarks][str(off)] = {}
+                for w in wf_list:
+                    internal_ret_dict[name][quarks][str(off)][str(w)] = {}
+                    for w2 in wf2_list:
+                        internal_ret_dict[name][quarks][str(off)][str(w)][str(w2)] = []
+    internal_ret_dict = benedict(internal_ret_dict, keypath_separator="/")
+    ret_key_paths = _get_deep_paths(internal_ret_dict)
+    return ret_key_paths, internal_ret_dict
+
+
+def _setup_intern_dict(name_list, corr_type_list, quarks_list, noffset_list, wf_list, wf2_list):
+    intern = {}
+    for name, corr_type in zip(name_list, corr_type_list):
+        intern[name] = {}
+        b2b, single = _extract_corr_type(corr_type)
+        intern[name]["b2b"] = b2b
+        intern[name]["single"] = single
+        intern[name]["spec"] = {}
+        for quarks in quarks_list:
+            intern[name]["spec"][quarks] = {}
+            for off in noffset_list:
+                intern[name]["spec"][quarks][str(off)] = {}
+                for w in wf_list:
+                    intern[name]["spec"][quarks][str(off)][str(w)] = {}
+                    for w2 in wf2_list:
+                        intern[name]["spec"][quarks][str(off)][str(w)][str(w2)] = {}
+    return intern
+
+
+def _read_o_file(cfg_path, name, intern, version, im, template):
     file = cfg_path + '/' + name
-    return_vals = {}
+    return_vals = deepcopy(template)
+    return_vals = return_vals.subset(name)[name]
+    print(return_vals)
     with open(file) as fp:
         lines = fp.readlines()
-        for quarks in intern[name]["spec"].keys():
-            return_vals[quarks] = {}
-            for off in intern[name]["spec"][quarks].keys():
-                return_vals[quarks][off] = {}
-                for w in intern[name]["spec"][quarks][off].keys():
-                    return_vals[quarks][off][w] = {}
-                    for w2 in intern[name]["spec"][quarks][off][w].keys():
-                        T = intern[name]["T"]
-                        start_read = intern[name]["spec"][quarks][off][w][w2]["start"]
-                        deltas = []
-                        for line in lines[start_read:start_read + T]:
-                            floats = list(map(float, line.split()))
-                            if version == "0.0":
-                                deltas.append(floats[im - intern[name]["single"]])
-                            else:
-                                deltas.append(floats[1 + im - intern[name]["single"]])
-                        return_vals[quarks][off][w][w2] = deltas
+        for k in _get_deep_paths(return_vals):
+            ori_keys = k.split("/")
+            quarks = ori_keys[0]
+            off = ori_keys[1]
+            w = ori_keys[2]
+            w2 = ori_keys[3]
+            T = intern[name]["T"]
+            start_read = intern[name]["spec"][quarks][off][w][w2]["start"]
+            deltas = []
+            for line in lines[start_read:start_read + T]:
+                floats = list(map(float, line.split()))
+                if version == "0.0":
+                    deltas.append(floats[im - intern[name]["single"]])
+                else:
+                    deltas.append(floats[1 + im - intern[name]["single"]])
+            return_vals[quarks][off][w][w2] = deltas
     return return_vals
 
 
@@ -468,67 +478,55 @@ def _find_correlator(file_name, version, pattern, b2b, silent=False):
     return start_read, T
 
 
-def _read_compact_file(rep_path, cfg_file, intern, im):
-    return_vals = {}
+def _read_compact_file(rep_path, cfg_file, intern, im, template):
+    return_vals = deepcopy(template)
     with open(rep_path + cfg_file) as fp:
         lines = fp.readlines()
-        for name in intern.keys():
-            return_vals[name] = {}
-            for quarks in intern[name]["spec"].keys():
-                return_vals[name][quarks] = {}
-                for off in intern[name]["spec"][quarks].keys():
-                    return_vals[name][quarks][off] = {}
-                    for w in intern[name]["spec"][quarks][off].keys():
-                        return_vals[name][quarks][off][w] = {}
-                        for w2 in intern[name]["spec"][quarks][off][w].keys():
-                            T = intern[name]["T"]
-                            start_read = intern[name]["spec"][quarks][off][w][w2]["start"]
-                            # check, if the correlator is in fact
-                            # printed completely
-                            if (start_read + T + 1 > len(lines)):
-                                raise Exception("EOF before end of correlator data! Maybe " + rep_path + cfg_file + " is corrupted?")
-                            corr_lines = lines[start_read - 6: start_read + T]
-                            t_vals = []
+        for key in _get_deep_paths(return_vals):
+            ori_keys = key.split("/")
+            name = ori_keys[0]
+            quarks = ori_keys[1]
+            off = ori_keys[2]
+            w = ori_keys[3]
+            w2 = ori_keys[4]
+            T = intern[name]["T"]
+            start_read = intern[name]["spec"][quarks][off][w][w2]["start"]
+            # check, if the correlator is in fact
+            # printed completely
+            if (start_read + T + 1 > len(lines)):
+                raise Exception("EOF before end of correlator data! Maybe " + rep_path + cfg_file + " is corrupted?")
+            corr_lines = lines[start_read - 6: start_read + T]
+            t_vals = []
 
-                            if corr_lines[1 - intern[name]["b2b"]].strip() != 'name      ' + name:
-                                raise Exception('Wrong format in file', cfg_file)
+            if corr_lines[1 - intern[name]["b2b"]].strip() != 'name      ' + name:
+                raise Exception('Wrong format in file', cfg_file)
 
-                            for k in range(6, T + 6):
-                                floats = list(map(float, corr_lines[k].split()))
-                                t_vals.append(floats[-2:][im])
-                            return_vals[name][quarks][off][w][w2] = t_vals
+            for k in range(6, T + 6):
+                floats = list(map(float, corr_lines[k].split()))
+                t_vals.append(floats[-2:][im])
+            return_vals[key] = t_vals
     return return_vals
 
 
-def _read_compact_rep(path, rep, sub_ls, intern, im_list):
+def _read_compact_rep(path, rep, sub_ls, intern, keys, im_list, template):
     rep_path = path + '/' + rep + '/'
     no_cfg = len(sub_ls)
-
-    return_vals = {}
-    for name in intern.keys():
-        return_vals[name] = {}
-        for quarks in intern[name]["spec"].keys():
-            return_vals[name][quarks] = {}
-            for off in intern[name]["spec"][quarks].keys():
-                return_vals[name][quarks][off] = {}
-                for w in intern[name]["spec"][quarks][off].keys():
-                    return_vals[name][quarks][off][w] = {}
-                    for w2 in intern[name]["spec"][quarks][off][w].keys():
-                        deltas = []
-                        for t in range(intern[name]["T"]):
-                            deltas.append(np.zeros(no_cfg))
-                        return_vals[name][quarks][off][w][w2] = deltas
-
+    print(template)
+    return_vals = deepcopy(template)
+    for k in keys:
+        name = k.split("/")[0]
+        deltas = []
+        for t in range(intern[name]["T"]):
+            deltas.append(np.zeros(no_cfg))
+        return_vals[k] = deltas
     for cfg in range(no_cfg):
         cfg_file = sub_ls[cfg]
-        cfg_data = _read_compact_file(rep_path, cfg_file, intern, im_list)
-        for name in intern.keys():
-            for quarks in intern[name]["spec"].keys():
-                for off in intern[name]["spec"][quarks].keys():
-                    for w in intern[name]["spec"][quarks][off].keys():
-                        for w2 in intern[name]["spec"][quarks][off][w].keys():
-                            for t in range(intern[name]["T"]):
-                                return_vals[name][quarks][off][w][w2][t][cfg] = cfg_data[name][quarks][off][w][w2][t]
+        cfg_data = _read_compact_file(rep_path, cfg_file, intern, im_list, template)
+        for k in keys:
+            name = k.split("/")[0]
+            for t in range(intern[name]["T"]):
+                return_vals[k][t][cfg] = cfg_data[k][t]
+    print(template)
     return return_vals
 
 
@@ -641,3 +639,13 @@ def _reduce_dict(d):
             if len(list(d.keys())) == 1:
                 ret = d[list(d.keys())[0]]
     return ret
+
+
+def _get_deep_paths(f, sep='/'):
+    max_count = max([k.count(sep) for k in f.keypaths()])
+
+    deep_paths = []
+    for k in f.keypaths():
+        if k.count(sep) == max_count:
+            deep_paths.append(k)
+    return deep_paths

--- a/pyerrors/input/utils.py
+++ b/pyerrors/input/utils.py
@@ -1,5 +1,8 @@
-import re
 """Utilities for the input"""
+
+import re
+import fnmatch
+import os
 
 
 def sort_names(ll):
@@ -75,3 +78,45 @@ def check_idl(idl, che):
             miss_str += "," + str(i)
         print(miss_str)
     return miss_str
+
+
+def check_params(path, param_hash, prefix, param_prefix):
+    ls = []
+    for (dirpath, dirnames, filenames) in os.walk(path):
+        ls.extend(dirnames)
+        break
+    if not ls:
+        raise Exception('Error, directory not found')
+    # Exclude folders with different names
+    for exc in ls:
+        if not fnmatch.fnmatch(exc, prefix + '*'):
+            ls = list(set(ls) - set([exc]))
+
+    ls = sort_names(ls)
+    nums = {}
+    for rep in ls:
+        rep_path = path + '/' + rep
+        # files of replicum
+        sub_ls = []
+        for (dirpath, dirnames, filenames) in os.walk(rep_path):
+            sub_ls.extend(filenames)
+
+        # filter
+        param_files = []
+        for file in sub_ls:
+            if fnmatch.fnmatch(file, param_prefix + '*'):
+                param_files.append(file)
+
+        rep_nums = ''
+        for file in param_files:
+            with open(rep_path + '/' + file) as fp:
+                for line in fp:
+                    pass
+                last_line = line
+                if last_line.split()[2] != param_hash:
+                    rep_nums += file.split("_")[1] + ','
+        nums[rep_path] = rep_nums
+
+        if not len(rep_nums) == 0:
+            raise Warning("found differing parameter hash in the param files in " + rep_path)
+    return nums

--- a/pyerrors/input/utils.py
+++ b/pyerrors/input/utils.py
@@ -20,6 +20,7 @@ def sort_names(ll):
     ll: list
         sorted list
     """
+
     if len(ll) > 1:
         sorted = False
         r_pattern = r'r(\d+)'
@@ -66,6 +67,7 @@ def check_idl(idl, che):
     miss_str : str
         string with integers of which idls are missing
     """
+
     missing = []
     for c in che:
         if c not in idl:
@@ -80,7 +82,27 @@ def check_idl(idl, che):
     return miss_str
 
 
-def check_params(path, param_hash, prefix, param_prefix):
+def check_params(path, param_hash, prefix, param_prefix = "parameters_"):
+    """
+    Check if, for sfcf, the parameter hashes at the end of the parameter files are in fact the expected one.
+
+    Parameters
+    ----------
+    path: str
+        measurement path, same as for sfcf read method
+    param_hash: str
+        expected parameter hash
+    prefix: str
+        data prefix to find the appropriate replicum folders in path
+    param_prefix: str
+        prefix of the parameter file. Defaults to 'parameters_'
+
+    Returns
+    -------
+    nums: dict
+        dictionary of faulty parameter files sorted by the replica paths
+    """
+
     ls = []
     for (dirpath, dirnames, filenames) in os.walk(path):
         ls.extend(dirnames)

--- a/pyerrors/input/utils.py
+++ b/pyerrors/input/utils.py
@@ -82,7 +82,7 @@ def check_idl(idl, che):
     return miss_str
 
 
-def check_params(path, param_hash, prefix, param_prefix = "parameters_"):
+def check_params(path, param_hash, prefix, param_prefix="parameters_"):
     """
     Check if, for sfcf, the parameter hashes at the end of the parameter files are in fact the expected one.
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name='pyerrors',
       license="MIT",
       packages=find_packages(),
       python_requires='>=3.8.0',
-      install_requires=['numpy>=1.24', 'autograd>=1.6.2', 'numdifftools>=0.9.41', 'matplotlib>=3.7', 'scipy>=1.10', 'iminuit>=2.21', 'h5py>=3.8', 'lxml>=4.9', 'python-rapidjson>=1.10', 'pandas>=2.0', 'python-benedict>=0.32.1'],
+      install_requires=['numpy>=1.24', 'autograd>=1.6.2', 'numdifftools>=0.9.41', 'matplotlib>=3.7', 'scipy>=1.10', 'iminuit>=2.21', 'h5py>=3.8', 'lxml>=4.9', 'python-rapidjson>=1.10', 'pandas>=2.0'],
       extras_require={'test': ['pytest', 'pytest-cov', 'pytest-benchmark', 'hypothesis', 'nbmake', 'flake8']},
       classifiers=[
           'Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name='pyerrors',
       license="MIT",
       packages=find_packages(),
       python_requires='>=3.8.0',
-      install_requires=['numpy>=1.24', 'autograd>=1.6.2', 'numdifftools>=0.9.41', 'matplotlib>=3.7', 'scipy>=1.10', 'iminuit>=2.21', 'h5py>=3.8', 'lxml>=4.9', 'python-rapidjson>=1.10', 'pandas>=2.0'],
+      install_requires=['numpy>=1.24', 'autograd>=1.6.2', 'numdifftools>=0.9.41', 'matplotlib>=3.7', 'scipy>=1.10', 'iminuit>=2.21', 'h5py>=3.8', 'lxml>=4.9', 'python-rapidjson>=1.10', 'pandas>=2.0', 'python-benedict>=0.32.1'],
       extras_require={'test': ['pytest', 'pytest-cov', 'pytest-benchmark', 'hypothesis', 'nbmake', 'flake8']},
       classifiers=[
           'Development Status :: 5 - Production/Stable',

--- a/tests/sfcf_in_test.py
+++ b/tests/sfcf_in_test.py
@@ -331,3 +331,10 @@ def test_read_compact_file():
     im = False
     with pytest.raises(Exception):
         sfin._read_compact_file(rep_path, config_file, start_read, T, b2b, name, im)
+
+
+def test_find_correlator():
+    file = "tests/data/sfcf_test/data_c/data_c_r0/data_c_r0_n1"
+    found_start, found_T = sfin._find_correlator(file, "2.0", "name      f_A\nquarks    lquark lquark\noffset    0\nwf        0", False, False)
+    assert found_start == 21
+    assert found_T == 3

--- a/tests/sfcf_in_test.py
+++ b/tests/sfcf_in_test.py
@@ -61,6 +61,45 @@ def test_o_bib(tmp_path):
     assert f_V0[2] == 683.6776090081005
 
 
+def test_simple_multi_o(tmp_path):
+    build_test_environment(str(tmp_path), "o", 5, 3)
+    f_V0 = sfin.read_sfcf_multi(str(tmp_path) + "/data_o", "test", ["F_V0"], quarks=["lquark lquark"], wf1_list=[0], wf2_list=[0], version="2.0", corr_type_list=["bib"], nice_output=True)
+    print(f_V0)
+    assert len(f_V0) == 3
+    assert list(f_V0[0].shape.keys()) == ["test_|r0", "test_|r1", "test_|r2"]
+    assert f_V0[0] == 683.6776090085115
+    assert f_V0[1] == 661.3188585582334
+    assert f_V0[2] == 683.6776090081005
+
+
+def test_dict_multi_o(tmp_path):
+    build_test_environment(str(tmp_path), "o", 5, 3)
+    corrs = sfin.read_sfcf_multi(str(tmp_path) + "/data_o", "test",
+                                 ["F_V0", "f_A", "f_1"], quarks_list=["lquark lquark"],
+                                 wf_list=[0], wf2_list=[0], version="2.0",
+                                 corr_type_list=["bib", "bi", "bb"], nice_output=False)
+    print(corrs)
+    f_1 = corrs["f_1"]['lquark lquark']['0']['0']['0']
+    f_A = corrs["f_A"]['lquark lquark']['0']['0']['0']
+    f_V0 = corrs["F_V0"]['lquark lquark']['0']['0']['0']
+
+    assert len(f_1) == 1
+    assert list(f_1[0].shape.keys()) == ["test_|r0", "test_|r1", "test_|r2"]
+    assert f_1[0].value == 351.1941525454502
+
+    assert len(f_A) == 3
+    assert list(f_A[0].shape.keys()) == ["test_|r0", "test_|r1", "test_|r2"]
+    assert f_A[0].value == 65.4711887279723
+    assert f_A[1].value == 1.0447210336915187
+    assert f_A[2].value == -41.025094911185185
+
+    assert len(f_V0) == 3
+    assert list(f_V0[0].shape.keys()) == ["test_|r0", "test_|r1", "test_|r2"]
+    assert f_V0[0] == 683.6776090085115
+    assert f_V0[1] == 661.3188585582334
+    assert f_V0[2] == 683.6776090081005
+
+
 def test_c_bb(tmp_path):
     build_test_environment(str(tmp_path), "c", 5, 3)
     f_1 = sfin.read_sfcf(str(tmp_path) + "/data_c", "data_c", "f_1", quarks="lquark lquark", wf=0, wf2=0, version="2.0c", corr_type="bb")
@@ -131,6 +170,72 @@ def test_dict_multi_c(tmp_path):
     assert f_V0[2] == 683.6776090081005
 
 
+def test_dict_multi_wf_c(tmp_path):
+    build_test_environment(str(tmp_path), "c", 5, 3)
+    corrs = sfin.read_sfcf_multi(str(tmp_path) + "/data_c", "data_c",
+                                 ["F_V0", "f_A", "f_1"], quarks_list=["lquark lquark"],
+                                 wf_list=[0, 1], wf2_list=[0, 1], version="2.0c",
+                                 corr_type_list=["bib", "bi", "bb"], nice_output=False)
+    rep_names = ["data_c_|r0", "data_c_|r1", "data_c_|r2"]
+    f_1_00 = corrs["f_1"]['lquark lquark']['0']['0']['0']
+    f_1_01 = corrs["f_1"]['lquark lquark']['0']['0']['1']
+    f_1_10 = corrs["f_1"]['lquark lquark']['0']['1']['0']
+    f_1_11 = corrs["f_1"]['lquark lquark']['0']['1']['1']
+
+    assert len(f_1_00) == 1
+    assert list(f_1_00[0].shape.keys()) == rep_names
+    assert f_1_00[0].value == 351.1941525454502
+
+    assert len(f_1_01) == 1
+    assert list(f_1_01[0].shape.keys()) == rep_names
+    assert f_1_01[0].value == 351.20703575855345
+
+    assert len(f_1_10) == 1
+    assert list(f_1_10[0].shape.keys()) == rep_names
+    assert f_1_10[0].value == 351.20703575855515
+
+    assert len(f_1_11) == 1
+    assert list(f_1_11[0].shape.keys()) == rep_names
+    assert f_1_11[0].value == 351.22001235609065
+
+    f_A = corrs["f_A"]['lquark lquark']['0']['0']['0']
+
+    assert len(f_A) == 3
+    assert list(f_A[0].shape.keys()) == rep_names
+    assert f_A[0].value == 65.4711887279723
+    assert f_A[1].value == 1.0447210336915187
+    assert f_A[2].value == -41.025094911185185
+
+    f_V0_00 = corrs["F_V0"]['lquark lquark']['0']['0']['0']
+    f_V0_01 = corrs["F_V0"]['lquark lquark']['0']['0']['1']
+    f_V0_10 = corrs["F_V0"]['lquark lquark']['0']['1']['0']
+    f_V0_11 = corrs["F_V0"]['lquark lquark']['0']['1']['1']
+
+    assert len(f_V0_00) == 3
+    assert list(f_V0_00[0].shape.keys()) == rep_names
+    assert f_V0_00[0].value == 683.6776090085115
+    assert f_V0_00[1].value == 661.3188585582334
+    assert f_V0_00[2].value == 683.6776090081005
+
+    assert len(f_V0_01) == 3
+    assert list(f_V0_01[0].shape.keys()) == rep_names
+    assert f_V0_01[0].value == 683.7028316879306
+    assert f_V0_01[1].value == 661.3432563640756
+    assert f_V0_01[2].value == 683.7028316875197
+
+    assert len(f_V0_10) == 3
+    assert list(f_V0_10[0].shape.keys()) == rep_names
+    assert f_V0_10[0].value == 683.7028316879289
+    assert f_V0_10[1].value == 661.343256364074
+    assert f_V0_10[2].value == 683.702831687518
+
+    assert len(f_V0_11) == 3
+    assert list(f_V0_11[0].shape.keys()) == rep_names
+    assert f_V0_11[0].value == 683.7280552978792
+    assert f_V0_11[1].value == 661.3676550700158
+    assert f_V0_11[2].value == 683.7280552974681
+
+
 def test_a_bb(tmp_path):
     build_test_environment(str(tmp_path), "a", 5, 3)
     f_1 = sfin.read_sfcf(str(tmp_path) + "/data_a", "data_a", "f_1", quarks="lquark lquark", wf=0, wf2=0, version="2.0a", corr_type="bb")
@@ -162,6 +267,45 @@ def test_a_bib(tmp_path):
     assert f_V0[2] == 683.6776090081005
 
 
+def test_simple_multi_a(tmp_path):
+    build_test_environment(str(tmp_path), "a", 5, 3)
+    f_V0 = sfin.read_sfcf_multi(str(tmp_path) + "/data_a", "data_a", ["F_V0"], quarks=["lquark lquark"], wf1_list=[0], wf2_list=[0], version="2.0a", corr_type_list=["bib"], nice_output=True)
+    print(f_V0)
+    assert len(f_V0) == 3
+    assert list(f_V0[0].shape.keys()) == ["data_a_|r0", "data_a_|r1", "data_a_|r2"]
+    assert f_V0[0] == 683.6776090085115
+    assert f_V0[1] == 661.3188585582334
+    assert f_V0[2] == 683.6776090081005
+
+
+def test_dict_multi_a(tmp_path):
+    build_test_environment(str(tmp_path), "a", 5, 3)
+    corrs = sfin.read_sfcf_multi(str(tmp_path) + "/data_a", "data_a",
+                                 ["F_V0", "f_A", "f_1"], quarks_list=["lquark lquark"],
+                                 wf_list=[0], wf2_list=[0], version="2.0a",
+                                 corr_type_list=["bib", "bi", "bb"], nice_output=False)
+    print(corrs)
+    f_1 = corrs["f_1"]['lquark lquark']['0']['0']['0']
+    f_A = corrs["f_A"]['lquark lquark']['0']['0']['0']
+    f_V0 = corrs["F_V0"]['lquark lquark']['0']['0']['0']
+
+    assert len(f_1) == 1
+    assert list(f_1[0].shape.keys()) == ["data_a_|r0", "data_a_|r1", "data_a_|r2"]
+    assert f_1[0].value == 351.1941525454502
+
+    assert len(f_A) == 3
+    assert list(f_A[0].shape.keys()) == ["data_a_|r0", "data_a_|r1", "data_a_|r2"]
+    assert f_A[0].value == 65.4711887279723
+    assert f_A[1].value == 1.0447210336915187
+    assert f_A[2].value == -41.025094911185185
+
+    assert len(f_V0) == 3
+    assert list(f_V0[0].shape.keys()) == ["data_a_|r0", "data_a_|r1", "data_a_|r2"]
+    assert f_V0[0] == 683.6776090085115
+    assert f_V0[1] == 661.3188585582334
+    assert f_V0[2] == 683.6776090081005
+
+
 def test_find_corr():
     pattern = 'name      ' + "f_A" + '\nquarks    ' + "lquark lquark" + '\noffset    ' + str(0) + '\nwf        ' + str(0)
     start_read, T = sfin._find_correlator("tests/data/sfcf_test/data_c/data_c_r0/data_c_r0_n1", "2.0c", pattern, False)
@@ -177,7 +321,7 @@ def test_find_corr():
         sfin._find_correlator("tests/data/sfcf_test/broken_data_c/data_c_r0/data_c_r0_n1", "2.0c", pattern, False)
 
 
-def test_read_compact_file(tmp_path):
+def test_read_compact_file():
     rep_path = "tests/data/sfcf_test/broken_data_c/data_c_r0/"
     config_file = "data_c_r0_n1"
     start_read = 469

--- a/tests/sfcf_in_test.py
+++ b/tests/sfcf_in_test.py
@@ -63,8 +63,8 @@ def test_o_bib(tmp_path):
 
 def test_simple_multi_o(tmp_path):
     build_test_environment(str(tmp_path), "o", 5, 3)
-    f_V0 = sfin.read_sfcf_multi(str(tmp_path) + "/data_o", "test", ["F_V0"], quarks=["lquark lquark"], wf1_list=[0], wf2_list=[0], version="2.0", corr_type_list=["bib"], nice_output=True)
-    print(f_V0)
+    corrs = sfin.read_sfcf_multi(str(tmp_path) + "/data_o", "test", ["F_V0"], quarks_list=["lquark lquark"], wf1_list=[0], wf2_list=[0], version="2.0", corr_type_list=["bib"])
+    f_V0 = corrs["F_V0"]['lquark lquark']['0']['0']['0']
     assert len(f_V0) == 3
     assert list(f_V0[0].shape.keys()) == ["test_|r0", "test_|r1", "test_|r2"]
     assert f_V0[0] == 683.6776090085115
@@ -133,8 +133,8 @@ def test_c_bib(tmp_path):
 
 def test_simple_multi_c(tmp_path):
     build_test_environment(str(tmp_path), "c", 5, 3)
-    f_V0 = sfin.read_sfcf_multi(str(tmp_path) + "/data_c", "data_c", ["F_V0"], quarks=["lquark lquark"], wf1_list=[0], wf2_list=[0], version="2.0c", corr_type_list=["bib"], nice_output=True)
-    print(f_V0)
+    corrs = sfin.read_sfcf_multi(str(tmp_path) + "/data_c", "data_c", ["F_V0"], quarks_list=["lquark lquark"], wf1_list=[0], wf2_list=[0], version="2.0c", corr_type_list=["bib"])
+    f_V0 = corrs["F_V0"]['lquark lquark']['0']['0']['0']
     assert len(f_V0) == 3
     assert list(f_V0[0].shape.keys()) == ["data_c_|r0", "data_c_|r1", "data_c_|r2"]
     assert f_V0[0] == 683.6776090085115
@@ -269,8 +269,8 @@ def test_a_bib(tmp_path):
 
 def test_simple_multi_a(tmp_path):
     build_test_environment(str(tmp_path), "a", 5, 3)
-    f_V0 = sfin.read_sfcf_multi(str(tmp_path) + "/data_a", "data_a", ["F_V0"], quarks=["lquark lquark"], wf1_list=[0], wf2_list=[0], version="2.0a", corr_type_list=["bib"], nice_output=True)
-    print(f_V0)
+    corrs = sfin.read_sfcf_multi(str(tmp_path) + "/data_a", "data_a", ["F_V0"], quarks_list=["lquark lquark"], wf1_list=[0], wf2_list=[0], version="2.0a", corr_type_list=["bib"])
+    f_V0 = corrs["F_V0"]['lquark lquark']['0']['0']['0']
     assert len(f_V0) == 3
     assert list(f_V0[0].shape.keys()) == ["data_a_|r0", "data_a_|r1", "data_a_|r2"]
     assert f_V0[0] == 683.6776090085115

--- a/tests/sfcf_in_test.py
+++ b/tests/sfcf_in_test.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import inspect
-import pyerrors as pe
 import pyerrors.input.sfcf as sfin
 import shutil
 import pytest
@@ -14,106 +13,154 @@ sys.path.insert(0, parent_dir)
 def build_test_environment(path, env_type, cfgs, reps):
     shutil.copytree("tests/data/sfcf_test/data_"+env_type, (path + "/data_" + env_type))
     if env_type == "o":
-        for i in range(2,cfgs+1):
+        for i in range(2, cfgs+1):
             shutil.copytree(path + "/data_o/test_r0/cfg1", path + "/data_o/test_r0/cfg"+str(i))
-        for i in range(1,reps):
+        for i in range(1, reps):
             shutil.copytree(path + "/data_o/test_r0", path + "/data_o/test_r"+str(i))
     elif env_type == "c":
-        for i in range(2,cfgs+1):
+        for i in range(2, cfgs+1):
             shutil.copy(path + "/data_c/data_c_r0/data_c_r0_n1", path + "/data_c/data_c_r0/data_c_r0_n"+str(i))
-        for i in range(1,reps):
+        for i in range(1, reps):
             os.mkdir(path + "/data_c/data_c_r"+str(i))
-            for j in range(1,cfgs+1):
-                shutil.copy(path + "/data_c/data_c_r0/data_c_r0_n1",path + "/data_c/data_c_r"+str(i)+"/data_c_r"+str(i)+"_n"+str(j))
+            for j in range(1, cfgs+1):
+                shutil.copy(path + "/data_c/data_c_r0/data_c_r0_n1", path + "/data_c/data_c_r"+str(i)+"/data_c_r"+str(i)+"_n"+str(j))
     elif env_type == "a":
-        for i in range(1,reps):
+        for i in range(1, reps):
             for corr in ["f_1", "f_A", "F_V0"]:
                 shutil.copy(path + "/data_a/data_a_r0." + corr, path + "/data_a/data_a_r" + str(i) + "." + corr)
 
 
 def test_o_bb(tmp_path):
-    build_test_environment(str(tmp_path), "o",5,3)
-    f_1 = sfin.read_sfcf(str(tmp_path) + "/data_o", "test", "f_1",quarks="lquark lquark", wf = 0, wf2=0, version = "2.0", corr_type="bb")
+    build_test_environment(str(tmp_path), "o", 5, 3)
+    f_1 = sfin.read_sfcf(str(tmp_path) + "/data_o", "test", "f_1", quarks="lquark lquark", wf=0, wf2=0, version="2.0", corr_type="bb")
     print(f_1)
     assert len(f_1) == 1
-    assert list(f_1[0].shape.keys()) == ["test_|r0","test_|r1","test_|r2"]
+    assert list(f_1[0].shape.keys()) == ["test_|r0", "test_|r1", "test_|r2"]
     assert f_1[0].value == 351.1941525454502
+
 
 def test_o_bi(tmp_path):
-    build_test_environment(str(tmp_path), "o",5,3)
-    f_A = sfin.read_sfcf(str(tmp_path) + "/data_o", "test", "f_A",quarks="lquark lquark", wf = 0, version = "2.0")
+    build_test_environment(str(tmp_path), "o", 5, 3)
+    f_A = sfin.read_sfcf(str(tmp_path) + "/data_o", "test", "f_A", quarks="lquark lquark", wf=0, version="2.0")
     print(f_A)
     assert len(f_A) == 3
-    assert list(f_A[0].shape.keys()) == ["test_|r0","test_|r1","test_|r2"]
+    assert list(f_A[0].shape.keys()) == ["test_|r0", "test_|r1", "test_|r2"]
     assert f_A[0].value == 65.4711887279723
     assert f_A[1].value == 1.0447210336915187
     assert f_A[2].value == -41.025094911185185
+
 
 def test_o_bib(tmp_path):
-    build_test_environment(str(tmp_path), "o",5,3)
-    f_V0 = sfin.read_sfcf(str(tmp_path) + "/data_o", "test", "F_V0",quarks="lquark lquark", wf = 0, wf2 = 0, version = "2.0", corr_type="bib")
+    build_test_environment(str(tmp_path), "o", 5, 3)
+    f_V0 = sfin.read_sfcf(str(tmp_path) + "/data_o", "test", "F_V0", quarks="lquark lquark", wf=0, wf2=0, version="2.0", corr_type="bib")
     print(f_V0)
     assert len(f_V0) == 3
-    assert list(f_V0[0].shape.keys()) == ["test_|r0","test_|r1","test_|r2"]
+    assert list(f_V0[0].shape.keys()) == ["test_|r0", "test_|r1", "test_|r2"]
     assert f_V0[0] == 683.6776090085115
     assert f_V0[1] == 661.3188585582334
     assert f_V0[2] == 683.6776090081005
+
 
 def test_c_bb(tmp_path):
-    build_test_environment(str(tmp_path), "c",5,3)
-    f_1 = sfin.read_sfcf(str(tmp_path) + "/data_c", "data_c", "f_1", quarks="lquark lquark", wf = 0, wf2=0, version = "2.0c", corr_type="bb")
+    build_test_environment(str(tmp_path), "c", 5, 3)
+    f_1 = sfin.read_sfcf(str(tmp_path) + "/data_c", "data_c", "f_1", quarks="lquark lquark", wf=0, wf2=0, version="2.0c", corr_type="bb")
     print(f_1)
     assert len(f_1) == 1
-    assert list(f_1[0].shape.keys()) == ["data_c_|r0","data_c_|r1","data_c_|r2"]
+    assert list(f_1[0].shape.keys()) == ["data_c_|r0", "data_c_|r1", "data_c_|r2"]
     assert f_1[0].value == 351.1941525454502
+
 
 def test_c_bi(tmp_path):
-    build_test_environment(str(tmp_path), "c",5,3)
-    f_A = sfin.read_sfcf(str(tmp_path) + "/data_c", "data_c", "f_A", quarks="lquark lquark", wf = 0, version = "2.0c")
+    build_test_environment(str(tmp_path), "c", 5, 3)
+    f_A = sfin.read_sfcf(str(tmp_path) + "/data_c", "data_c", "f_A", quarks="lquark lquark", wf=0, version="2.0c")
     print(f_A)
     assert len(f_A) == 3
-    assert list(f_A[0].shape.keys()) == ["data_c_|r0","data_c_|r1","data_c_|r2"]
+    assert list(f_A[0].shape.keys()) == ["data_c_|r0", "data_c_|r1", "data_c_|r2"]
     assert f_A[0].value == 65.4711887279723
     assert f_A[1].value == 1.0447210336915187
     assert f_A[2].value == -41.025094911185185
+
 
 def test_c_bib(tmp_path):
-    build_test_environment(str(tmp_path), "c",5,3)
-    f_V0 = sfin.read_sfcf(str(tmp_path) + "/data_c", "data_c", "F_V0",quarks="lquark lquark", wf = 0, wf2 = 0, version = "2.0c", corr_type="bib")
+    build_test_environment(str(tmp_path), "c", 5, 3)
+    f_V0 = sfin.read_sfcf(str(tmp_path) + "/data_c", "data_c", "F_V0", quarks="lquark lquark", wf=0, wf2=0, version="2.0c", corr_type="bib")
     print(f_V0)
     assert len(f_V0) == 3
-    assert list(f_V0[0].shape.keys()) == ["data_c_|r0","data_c_|r1","data_c_|r2"]
+    assert list(f_V0[0].shape.keys()) == ["data_c_|r0", "data_c_|r1", "data_c_|r2"]
     assert f_V0[0] == 683.6776090085115
     assert f_V0[1] == 661.3188585582334
     assert f_V0[2] == 683.6776090081005
 
-def test_a_bb(tmp_path):
-    build_test_environment(str(tmp_path), "a",5,3)
-    f_1 = sfin.read_sfcf(str(tmp_path) + "/data_a", "data_a", "f_1", quarks="lquark lquark", wf = 0, wf2=0, version = "2.0a", corr_type="bb")
-    print(f_1)
+
+def test_simple_multi_c(tmp_path):
+    build_test_environment(str(tmp_path), "c", 5, 3)
+    f_V0 = sfin.read_sfcf_multi(str(tmp_path) + "/data_c", "data_c", ["F_V0"], quarks=["lquark lquark"], wf1_list=[0], wf2_list=[0], version="2.0c", corr_type_list=["bib"], nice_output=True)
+    print(f_V0)
+    assert len(f_V0) == 3
+    assert list(f_V0[0].shape.keys()) == ["data_c_|r0", "data_c_|r1", "data_c_|r2"]
+    assert f_V0[0] == 683.6776090085115
+    assert f_V0[1] == 661.3188585582334
+    assert f_V0[2] == 683.6776090081005
+
+
+def test_dict_multi_c(tmp_path):
+    build_test_environment(str(tmp_path), "c", 5, 3)
+    corrs = sfin.read_sfcf_multi(str(tmp_path) + "/data_c", "data_c",
+                                 ["F_V0", "f_A", "f_1"], quarks_list=["lquark lquark"],
+                                 wf_list=[0], wf2_list=[0], version="2.0c",
+                                 corr_type_list=["bib", "bi", "bb"], nice_output=False)
+    print(corrs)
+    f_1 = corrs["f_1"]['lquark lquark']['0']['0']['0']
+    f_A = corrs["f_A"]['lquark lquark']['0']['0']['0']
+    f_V0 = corrs["F_V0"]['lquark lquark']['0']['0']['0']
+
     assert len(f_1) == 1
-    assert list(f_1[0].shape.keys()) == ["data_a_|r0","data_a_|r1","data_a_|r2"]
+    assert list(f_1[0].shape.keys()) == ["data_c_|r0", "data_c_|r1", "data_c_|r2"]
     assert f_1[0].value == 351.1941525454502
 
-def test_a_bi(tmp_path):
-    build_test_environment(str(tmp_path), "a",5,3)
-    f_A = sfin.read_sfcf(str(tmp_path) + "/data_a", "data_a", "f_A", quarks="lquark lquark", wf = 0, version = "2.0a")
-    print(f_A)
     assert len(f_A) == 3
-    assert list(f_A[0].shape.keys()) == ["data_a_|r0","data_a_|r1","data_a_|r2"]
+    assert list(f_A[0].shape.keys()) == ["data_c_|r0", "data_c_|r1", "data_c_|r2"]
     assert f_A[0].value == 65.4711887279723
     assert f_A[1].value == 1.0447210336915187
     assert f_A[2].value == -41.025094911185185
 
-def test_a_bib(tmp_path):
-    build_test_environment(str(tmp_path), "a",5,3)
-    f_V0 = sfin.read_sfcf(str(tmp_path) + "/data_a", "data_a", "F_V0",quarks="lquark lquark", wf = 0, wf2 = 0, version = "2.0a", corr_type="bib")
-    print(f_V0)
     assert len(f_V0) == 3
-    assert list(f_V0[0].shape.keys()) == ["data_a_|r0","data_a_|r1","data_a_|r2"]
+    assert list(f_V0[0].shape.keys()) == ["data_c_|r0", "data_c_|r1", "data_c_|r2"]
     assert f_V0[0] == 683.6776090085115
     assert f_V0[1] == 661.3188585582334
     assert f_V0[2] == 683.6776090081005
+
+
+def test_a_bb(tmp_path):
+    build_test_environment(str(tmp_path), "a", 5, 3)
+    f_1 = sfin.read_sfcf(str(tmp_path) + "/data_a", "data_a", "f_1", quarks="lquark lquark", wf=0, wf2=0, version="2.0a", corr_type="bb")
+    print(f_1)
+    assert len(f_1) == 1
+    assert list(f_1[0].shape.keys()) == ["data_a_|r0", "data_a_|r1", "data_a_|r2"]
+    assert f_1[0].value == 351.1941525454502
+
+
+def test_a_bi(tmp_path):
+    build_test_environment(str(tmp_path), "a", 5, 3)
+    f_A = sfin.read_sfcf(str(tmp_path) + "/data_a", "data_a", "f_A", quarks="lquark lquark", wf=0, version="2.0a")
+    print(f_A)
+    assert len(f_A) == 3
+    assert list(f_A[0].shape.keys()) == ["data_a_|r0", "data_a_|r1", "data_a_|r2"]
+    assert f_A[0].value == 65.4711887279723
+    assert f_A[1].value == 1.0447210336915187
+    assert f_A[2].value == -41.025094911185185
+
+
+def test_a_bib(tmp_path):
+    build_test_environment(str(tmp_path), "a", 5, 3)
+    f_V0 = sfin.read_sfcf(str(tmp_path) + "/data_a", "data_a", "F_V0", quarks="lquark lquark", wf=0, wf2=0, version="2.0a", corr_type="bib")
+    print(f_V0)
+    assert len(f_V0) == 3
+    assert list(f_V0[0].shape.keys()) == ["data_a_|r0", "data_a_|r1", "data_a_|r2"]
+    assert f_V0[0] == 683.6776090085115
+    assert f_V0[1] == 661.3188585582334
+    assert f_V0[2] == 683.6776090081005
+
 
 def test_find_corr():
     pattern = 'name      ' + "f_A" + '\nquarks    ' + "lquark lquark" + '\noffset    ' + str(0) + '\nwf        ' + str(0)
@@ -128,6 +175,7 @@ def test_find_corr():
     pattern = 'name      ' + "f_A" + '\nquarks    ' + "lquark lquark" + '\noffset    ' + str(0) + '\nwf        ' + str(0)
     with pytest.raises(ValueError):
         sfin._find_correlator("tests/data/sfcf_test/broken_data_c/data_c_r0/data_c_r0_n1", "2.0c", pattern, False)
+
 
 def test_read_compact_file(tmp_path):
     rep_path = "tests/data/sfcf_test/broken_data_c/data_c_r0/"


### PR DESCRIPTION
Hey there,

so as I mentioned in a previous pull request, I wanted to rewrite the read_sfcf method again.
So... I did. There is now a method "read_sfcf_multi", which is a superset of the "read_sfcf" method.
The read_sfcf method is now simply routed through the new method.
All of this was done for the following reason: I have tried to accelerate the reading of sfcf measurements in my projects for some time.
Finally, I found that the main time is spent in IO, as per read every file is opened once.
As it is usual to not read one correlator at a time, but e.g. 8 correlators at a time, this results in 8 $\times$ \#cnfg `open(file)` calls, which needs to retrieve the file from disk and loads it in the buffer.
Instead, now I am doing the following:
I directly read *all* relevant correlators from a file, then move on to the next file. Therefore I only need \#cnfg `open(file)` calls. The drawback being that afterwards I have to manage unpacking a python dict, which can be done much faster.

Here some benchmarks taken with `timeit`:

\#cnfg 2146

Old implementation:
\#corrs 72
read_sfcf 70.942 s

New implementation:
\#corrs 72
read_sfcf 71.462 s
read_sfcf_multi 4.777 s

\#corrs 36
read_sfcf 34.308 s
read_sfcf_multi 2.280 s

\#corrs 20
read_sfcf 18.421 s
read_sfcf_multi 1.653 s

This new functionality is not yet tested extensively (mainly I have done the tests by pytest that are also in this PR and the benchmarks on a set of measurements that I have for a project of mine). 