### PR TITLE
Fixed bugs for combined fits with multiple independent variables

### DIFF
--- a/pyerrors/fits.py
+++ b/pyerrors/fits.py
@@ -365,7 +365,7 @@ def least_squares(x, y, func, priors=None, silent=False, **kwargs):
         raise Exception('The minimization procedure did not converge.')
 
     output.chisquare = chisquare
-    output.dof = x_all.shape[-1] - n_parms + len(loc_priors)
+    output.dof = y_all.shape[-1] - n_parms + len(loc_priors)
     output.p_value = 1 - scipy.stats.chi2.cdf(output.chisquare, output.dof)
     if output.dof > 0:
         output.chisquare_by_dof = output.chisquare / output.dof
@@ -393,7 +393,7 @@ def least_squares(x, y, func, priors=None, silent=False, **kwargs):
             hat_vector = prepare_hat_matrix()
             A = W @ hat_vector
             P_phi = A @ np.linalg.pinv(A.T @ A) @ A.T
-            expected_chisquare = np.trace((np.identity(x_all.shape[-1]) - P_phi) @ W @ cov @ W)
+            expected_chisquare = np.trace((np.identity(y_all.shape[-1]) - P_phi) @ W @ cov @ W)
             output.chisquare_by_expected_chisquare = output.chisquare / expected_chisquare
             if not silent:
                 print('chisquare/expected_chisquare:', output.chisquare_by_expected_chisquare)


### PR DESCRIPTION
This fixes two bugs that were present in `least_squares` when doing a combined fit with multiple independent variables. The reason for the bug was that transposing the concatenation of the x values did not result in the expected shape. 

This fixes:
- The computation of the number of degrees of freedom works now correctly.
- The computation of the expected chi^2 does not throw an error anymore.

I furthermore discovered that the expected chi^2 with priors is not correctly evaluated. Therefore I have written the tests such that they don't detect this. I think I know what to do, but let's fix this bug first.