### PR TITLE
fix: Check if configs appears multiple times when creating an obs

### DIFF
--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -104,7 +104,9 @@ class Obs:
                 elif isinstance(idx, (list, np.ndarray)):
                     dc = np.unique(np.diff(idx))
                     if np.any(dc < 0):
-                        raise ValueError("Unsorted idx for idl[%s]" % (name))
+                        raise ValueError("Unsorted idx for idl[%s] at position %s" % (name, ' '.join(['%s' % (pos + 1) for pos in np.where(np.diff(idx) < 0)[0]])))
+                    elif np.any(dc == 0):
+                        raise ValueError("Duplicate entries in idx for idl[%s] at position %s" % (name, ' '.join(['%s' % (pos + 1) for pos in np.where(np.diff(idx) == 0)[0]])))
                     if len(dc) == 1:
                         self.idl[name] = range(idx[0], idx[-1] + dc[0], dc[0])
                     else:

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -40,6 +40,10 @@ def test_Obs_exceptions():
         pe.Obs([np.random.rand(4)], ['name'])
     with pytest.raises(ValueError):
         pe.Obs([np.random.rand(5)], ['1'], idl=[[5, 3, 2 ,4 ,1]])
+    with pytest.raises(ValueError):
+        pe.Obs([np.random.rand(5)], ['1'], idl=[[1, 2, 3, 3, 5]])
+    with pytest.raises(ValueError):
+        pe.Obs([np.random.rand(5)], ['1'], idl=[[1, 1, 3, 1, 5]])
     with pytest.raises(TypeError):
         pe.Obs([np.random.rand(5)], ['1'], idl=['t'])
     with pytest.raises(ValueError):


### PR DESCRIPTION
We now check that each `idx` is sorted in ascending order when creating an `Obs` and provide more helpful error messages when this is not the case.

Closes #214 