### PR TITLE
Special function module

### DIFF
--- a/pyerrors/__init__.py
+++ b/pyerrors/__init__.py
@@ -487,5 +487,6 @@ from . import linalg
 from . import mpm
 from . import roots
 from . import integrate
+from . import special
 
 from .version import __version__

--- a/pyerrors/misc.py
+++ b/pyerrors/misc.py
@@ -20,7 +20,7 @@ def print_config():
               "pandas": pd.__version__}
 
     for key, value in config.items():
-        print(f"{key : <10}\t {value}")
+        print(f"{key: <10}\t {value}")
 
 
 def errorbar(x, y, axes=plt, **kwargs):

--- a/pyerrors/special.py
+++ b/pyerrors/special.py
@@ -1,0 +1,17 @@
+import scipy
+import numpy as np
+from autograd.extend import primitive, defvjp
+from autograd.scipy.special import j0, y0, j1, y1, jn, yn, i0, i1, iv, ive
+
+
+__all__ = ["kn", "j0", "y0", "j1", "y1", "jn", "yn", "i0", "i1", "iv", "ive"]
+
+
+@primitive
+def kn(n, x):
+    if int(n) != n:
+        raise TypeError("The order 'n' needs to be an integer.")
+    return scipy.special.kn(n, x)
+
+
+defvjp(kn, None, lambda ans, n, x: lambda g: - g * 0.5 * (kn(np.abs(n - 1), x) + kn(n + 1, x)))

--- a/pyerrors/special.py
+++ b/pyerrors/special.py
@@ -1,17 +1,20 @@
 import scipy
 import numpy as np
 from autograd.extend import primitive, defvjp
-from autograd.scipy.special import j0, y0, j1, y1, jn, yn, i0, i1, iv, ive
+from autograd.scipy.special import j0, y0, j1, y1, jn, yn, i0, i1, iv, ive, beta, betainc, betaln
+from autograd.scipy.special import polygamma, psi, digamma, gamma, gammaln, gammainc, gammaincc, gammasgn, rgamma, multigammaln
+from autograd.scipy.special import erf, erfc, erfinv, erfcinv, logit, expit, logsumexp
 
 
 __all__ = ["beta", "betainc", "betaln",
            "polygamma", "psi", "digamma", "gamma", "gammaln", "gammainc", "gammaincc", "gammasgn", "rgamma", "multigammaln",
            "kn", "j0", "y0", "j1", "y1", "jn", "yn", "i0", "i1", "iv", "ive",
-           "erf", "erfc", "erfinc", "erfcinv", "logit", "expit", "logsumsexp"]
+           "erf", "erfc", "erfinv", "erfcinv", "logit", "expit", "logsumexp"]
 
 
 @primitive
 def kn(n, x):
+    """Modified Bessel function of the second kind of integer order n"""
     if int(n) != n:
         raise TypeError("The order 'n' needs to be an integer.")
     return scipy.special.kn(n, x)

--- a/pyerrors/special.py
+++ b/pyerrors/special.py
@@ -4,7 +4,10 @@ from autograd.extend import primitive, defvjp
 from autograd.scipy.special import j0, y0, j1, y1, jn, yn, i0, i1, iv, ive
 
 
-__all__ = ["kn", "j0", "y0", "j1", "y1", "jn", "yn", "i0", "i1", "iv", "ive"]
+__all__ = ["beta", "betainc", "betaln",
+           "polygamma", "psi", "digamma", "gamma", "gammaln", "gammainc", "gammaincc", "gammasgn", "rgamma", "multigammaln",
+           "kn", "j0", "y0", "j1", "y1", "jn", "yn", "i0", "i1", "iv", "ive",
+           "erf", "erfc", "erfinc", "erfcinv", "logit", "expit", "logsumsexp"]
 
 
 @primitive

--- a/tests/special_test.py
+++ b/tests/special_test.py
@@ -9,4 +9,4 @@ from numdifftools import Jacobian as num_jacobian
 def test_kn():
     for n in np.arange(0, 10):
         for val in np.linspace(0.1, 7.3, 10):
-            assert np.isclose(num_jacobian(lambda x: pe.special.kn(n, x))(val), jacobian(lambda x: pe.special.kn(n, x))(val), rtol=1e-10, atol=1e-10)
+            assert np.isclose(num_jacobian(lambda x: scipy.special.kn(n, x))(val), jacobian(lambda x: pe.special.kn(n, x))(val), rtol=1e-10, atol=1e-10)

--- a/tests/special_test.py
+++ b/tests/special_test.py
@@ -1,0 +1,12 @@
+import numpy as np
+import scipy
+import pyerrors as pe
+import pytest
+
+from autograd import jacobian
+from numdifftools import Jacobian as num_jacobian
+
+def test_kn():
+    for n in np.arange(0, 10):
+        for val in np.linspace(0.1, 7.3, 10):
+            assert np.isclose(num_jacobian(lambda x: pe.special.kn(n, x))(val), jacobian(lambda x: pe.special.kn(n, x))(val), rtol=1e-10, atol=1e-10)


### PR DESCRIPTION
Here is a first draft for a `special` module which adds support for automatic differentation for the Bessel functions implemented in scipy. There are a few more functions which are already supported in `autograd` but I did not explicilty import them yet.

This module could also host functions which are not implemented in scipy, like for example the Lüscher Zeta functions.