### PR TITLE
[ci] Install pyarrow in pytest workflow to silence pandas warnings.

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -41,6 +41,7 @@ jobs:
           pip install pytest-benchmark
           pip install hypothesis
           pip install py
+          pip install pyarrow
           pip freeze
 
       - name: Run tests


### PR DESCRIPTION
Yesterday's pandas 2.2.0 release includes the following warning:
```
DeprecationWarning: 
Pyarrow will become a required dependency of pandas in the next major release of pandas (pandas 3.0),
(to allow more performant data types, such as the Arrow string type, and better interoperability with other libraries)
but was not found to be installed on your system.
If this would cause problems for you,
please provide us feedback at https://github.com/pandas-dev/pandas/issues/54466
```
which causes our pipeline to fail because of the strict `-Werror` setting.

This PR adds `pip install pyarrow` to the workflow which should silence the warning and fix our piepline.