### PR TITLE
bugfix: read bb and bib/bi corr in one with keyed_out

### DIFF
--- a/pyerrors/input/sfcf.py
+++ b/pyerrors/input/sfcf.py
@@ -348,6 +348,7 @@ def read_sfcf_multi(path, prefix, name_list, quarks_list=['.*'], corr_type_list=
     result_dict = {}
     if keyed_out:
         for key in needed_keys:
+            name = _key2specs(key)[0]
             result = []
             for t in range(intern[name]["T"]):
                 result.append(Obs(internal_ret_dict[key][t], new_names, idl=idl))


### PR DESCRIPTION
Hey, I just noticed a small bug fir `read_sfcf_multi`, that turns up, when trying to read boundary-to-boundary correlators and boundary-bulk correlators in one go.
Looking up the time extend `T` of the respective correlator helps :)