### PR TITLE
fix: corrected bug that prevented combined fits with multiple x-obs in some cases

### DIFF
--- a/pyerrors/fits.py
+++ b/pyerrors/fits.py
@@ -256,7 +256,7 @@ def least_squares(x, y, func, priors=None, silent=False, **kwargs):
     if sorted(list(funcd.keys())) != key_ls:
         raise ValueError('x and func dictionaries do not contain the same keys.')
 
-    x_all = np.concatenate([np.array(xd[key]) for key in key_ls])
+    x_all = np.concatenate([np.array(xd[key]).transpose() for key in key_ls]).transpose()
     y_all = np.concatenate([np.array(yd[key]) for key in key_ls])
 
     y_f = [o.value for o in y_all]

--- a/tests/fits_test.py
+++ b/tests/fits_test.py
@@ -1082,6 +1082,18 @@ def test_combined_resplot_qqplot():
     fr = pe.least_squares(xd, yd, fd, resplot=True, qqplot=True)
     plt.close('all')
 
+def test_combined_fit_xerr():
+    fitd = {
+        'a' : lambda p, x: p[0] * x[0] + p[1] * x[1],
+        'b' : lambda p, x: p[0] * x[0] + p[2] * x[1],
+    }
+    yd = {
+        'a': [pe.cov_Obs(3 + .1 * np.random.uniform(), .1**2, 'a' + str(i)) for i in range(5)],
+        'b': [pe.cov_Obs(1 + .1 * np.random.uniform(), .1**2, 'b' + str(i)) for i in range(6)],
+    }
+    xd = {k: np.transpose([[1 + .01 * np.random.uniform(), 2] for i in range(len(yd[k]))]) for k in fitd}
+    pe.fits.least_squares(xd, yd, fitd)
+
 
 def test_x_multidim_fit():
     x1 = np.arange(1, 10)

--- a/tests/fits_test.py
+++ b/tests/fits_test.py
@@ -1086,10 +1086,12 @@ def test_combined_fit_xerr():
     fitd = {
         'a' : lambda p, x: p[0] * x[0] + p[1] * x[1],
         'b' : lambda p, x: p[0] * x[0] + p[2] * x[1],
+        'c' : lambda p, x: p[0] * x[0] + p[3] * x[1],
     }
     yd = {
         'a': [pe.cov_Obs(3 + .1 * np.random.uniform(), .1**2, 'a' + str(i)) for i in range(5)],
         'b': [pe.cov_Obs(1 + .1 * np.random.uniform(), .1**2, 'b' + str(i)) for i in range(6)],
+        'c': [pe.cov_Obs(3 + .1 * np.random.uniform(), .1**2, 'c' + str(i)) for i in range(3)],
     }
     xd = {k: np.transpose([[1 + .01 * np.random.uniform(), 2] for i in range(len(yd[k]))]) for k in fitd}
     pe.fits.least_squares(xd, yd, fitd)

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -276,10 +276,10 @@ def test_matrix_functions():
     for (i, j), entry in np.ndenumerate(check_inv):
         entry.gamma_method()
         if(i == j):
-            assert math.isclose(entry.value, 1.0, abs_tol=1e-9), 'value ' + str(i) + ',' + str(j) + ' ' + str(entry.value)
+            assert math.isclose(entry.value, 1.0, abs_tol=2e-9), 'value ' + str(i) + ',' + str(j) + ' ' + str(entry.value)
         else:
-            assert math.isclose(entry.value, 0.0, abs_tol=1e-9), 'value ' + str(i) + ',' + str(j) + ' ' + str(entry.value)
-        assert math.isclose(entry.dvalue, 0.0, abs_tol=1e-9), 'dvalue ' + str(i) + ',' + str(j) + ' ' + str(entry.dvalue)
+            assert math.isclose(entry.value, 0.0, abs_tol=2e-9), 'value ' + str(i) + ',' + str(j) + ' ' + str(entry.value)
+        assert math.isclose(entry.dvalue, 0.0, abs_tol=2e-9), 'dvalue ' + str(i) + ',' + str(j) + ' ' + str(entry.dvalue)
 
     # Check Cholesky decomposition
     sym = np.dot(matrix, matrix.T)

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -554,11 +554,11 @@ def test_merge_idx():
 
     for j in range(5):
         idll = [range(1, int(round(np.random.uniform(300, 700))), int(round(np.random.uniform(1, 14)))) for i in range(10)]
-        assert pe.obs._merge_idx(idll) == sorted(set().union(*idll))
+        assert list(pe.obs._merge_idx(idll)) == sorted(set().union(*idll))
 
     for j in range(5):
         idll = [range(int(round(np.random.uniform(1, 28))), int(round(np.random.uniform(300, 700))), int(round(np.random.uniform(1, 14)))) for i in range(10)]
-        assert pe.obs._merge_idx(idll) == sorted(set().union(*idll))
+        assert list(pe.obs._merge_idx(idll)) == sorted(set().union(*idll))
 
     idl = [list(np.arange(1, 14)) + list(range(16, 100, 4)), range(4, 604, 4), [2, 4, 5, 6, 8, 9, 12, 24], range(1, 20, 1), range(50, 789, 7)]
     new_idx = pe.obs._merge_idx(idl)


### PR DESCRIPTION
It was not possible to perform combined fits which rely on more than one x-obs when the data sets had unequal numbers of observations. The case that failed is given in the newly implemented test function. 
The bugfix ensures that the data sets are combined appropriately.