### PR TITLE
[Build] Release workflow added.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build sdist and wheel
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      name: Checkout repository
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+
+    - name: Build wheel and source tarball
+      run: python3 -m build
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+        if-no-files-found: error
+
+  publish:
+    needs: [build]
+    name: Upload to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pyerrors
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Sanity check
+        run: ls -la dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This PR introduces a release workflow that automatically releases a new version on PyPI whenever a release is created on GitHub. This should simplify releases and allow everyone with collaborator permissions on GitHub to release a new PyPI version @s-kuberski @jkuhl-uni. I can also grant these permissions to @JanNeuendorf and @PiaLJP if you are interested.

Here is a summary of our current release process:
1. Update CHANGELOG and README. Bump version number in `pyerrors/version.py` (respecting [semantic versioning](https://semver.org/)).
2. Merge the `develop` branch into `master` (and push to GitHub).
3. Create a GitHub release with target `master`, tag `v2.x.y` and write brief release notes. This will trigger a PyPI release which then triggers a conda-forge release.
4. Bump version number on the `develop` branch to `2.(x+1).0-dev`.