### PR TITLE
[Feat] Meas class for gaussian error propagation.

### DIFF
--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -1484,3 +1484,11 @@ def test_meas():
 def test_square_cov_obs():
     cov = pe.cov_Obs(1, 0.1 ** 2, "testing")
     cov2 = cov ** 2
+
+
+def test_covobs_equal_meas():
+    value = 1.1
+    standard_error = 0.23
+    meas = pe.Meas(value, standard_error)
+    covo = pe.cov_Obs(value, standard_error ** 2, meas.names[0])
+    assert covo == meas

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -1458,3 +1458,29 @@ def test_missing_replica():
     for op in [[O1O2, O1O2b], [O1O2O3, O1O2O3b]]:
         assert np.isclose(op[1].value, op[0].value)
         assert np.isclose(op[1].dvalue, op[0].dvalue, atol=0, rtol=5e-2)
+
+
+def test_meas():
+    meas1 = pe.Meas(1.0, 0.1)
+    meas2 = pe.Meas(2, 1)
+
+    assert meas1 + meas2 == meas2 + meas1
+    assert meas1 - meas2 == -(meas2 - meas1)
+    assert meas1 * meas2 == meas2 * meas1
+
+    identical_sum = meas1 + meas1
+    assert identical_sum == 2 * meas1
+    assert np.isclose(identical_sum.dvalue, 2 * meas1.dvalue)
+
+    meas1_new = pe.Meas(1.0, 0.1)
+    not_identical_sum = meas1 + meas1_new
+    assert not_identical_sum.value == (2 * meas1).value
+    assert not_identical_sum != 2 * meas1
+    assert np.isclose(not_identical_sum.dvalue, np.sqrt(meas1.dvalue ** 2 + meas1_new.dvalue ** 2))
+
+    assert meas2 * meas2 == meas2 ** 2
+
+
+def test_square_cov_obs():
+    cov = pe.cov_Obs(1, 0.1 ** 2, "testing")
+    cov2 = cov ** 2


### PR DESCRIPTION
I sometimes want to do Gaussian error propagation and find the syntax for creating a scalar cov_Obs a bit inconvenient. For this reason I propose a `Meas` class that simplifies this.
```python
import pyerrors as pe
value = 1.1
standard_error = 0.23
meas = pe.Meas(value, standard_error)
covo = pe.cov_Obs(value, standard_error ** 2, meas.names[0])
assert covo == meas
```

Standard errors do not need to be squared and if no name is provided, a uuid is generated instead.  I also propose to automatically evaluate the gamma method when an Obs exclusively consists of `cov_Obs` / `Meas` as the error estimation should be unambigous and the performance oberhead should be minimal.

In the process I also found a small bug in the cov_Obs implementation.