### PR TITLE
[Feat] Provide derivatives for pow

### DIFF
--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -861,10 +861,7 @@ class Obs:
             return derived_observable(lambda x, **kwargs: x[0] ** y, [self], man_grad=[y * self.value ** (y - 1)])
 
     def __rpow__(self, y):
-        if isinstance(y, Obs):
-            return derived_observable(lambda x: x[0] ** x[1], [y, self])
-        else:
-            return derived_observable(lambda x: y ** x[0], [self])
+        return derived_observable(lambda x, **kwargs: y ** x[0], [self], man_grad=[y ** self.value * np.log(y)])
 
     def __abs__(self):
         return derived_observable(lambda x: anp.abs(x[0]), [self])

--- a/pyerrors/obs.py
+++ b/pyerrors/obs.py
@@ -856,9 +856,9 @@ class Obs:
 
     def __pow__(self, y):
         if isinstance(y, Obs):
-            return derived_observable(lambda x: x[0] ** x[1], [self, y])
+            return derived_observable(lambda x, **kwargs: x[0] ** x[1], [self, y], man_grad=[y.value * self.value ** (y.value - 1), self.value ** y.value * np.log(self.value)])
         else:
-            return derived_observable(lambda x: x[0] ** y, [self])
+            return derived_observable(lambda x, **kwargs: x[0] ** y, [self], man_grad=[y * self.value ** (y - 1)])
 
     def __rpow__(self, y):
         if isinstance(y, Obs):

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -461,6 +461,17 @@ def test_cobs_overloading():
     obs / cobs
 
 
+def test_pow():
+    data = [1, 2.341, pe.pseudo_Obs(4.8, 0.48, "test_obs"), pe.cov_Obs(1.1, 0.3 ** 2, "test_cov_obs")]
+
+    for d in data:
+        assert d * d == d ** 2
+        assert d * d * d == d ** 3
+
+        for d2 in data:
+            assert np.log(d ** d2) == d2 * np.log(d)
+
+
 def test_reweighting():
     my_obs = pe.Obs([np.random.rand(1000)], ['t'])
     assert not my_obs.reweighted

--- a/tests/obs_test.py
+++ b/tests/obs_test.py
@@ -470,6 +470,7 @@ def test_pow():
 
         for d2 in data:
             assert np.log(d ** d2) == d2 * np.log(d)
+            assert (d ** d2) ** (1 / d2) == d
 
 
 def test_reweighting():


### PR DESCRIPTION
I explicitly added the derivatives for `__pow__` and `__rpow__`, previously these were estimated via autograd. On my machine this results in a ~4x speedup for pow operations, `obs ** 2` is now slightly faster than `obs * obs`.

I removed the `Obs` case from `__rpow__` as this should be covered by `__pow__` already and none of our tests fail 🤞 