### PR TITLE
[Feat] Introduce checks of the provided inverse matrix for correlated fits

### DIFF
--- a/pyerrors/fits.py
+++ b/pyerrors/fits.py
@@ -365,6 +365,8 @@ def least_squares(x, y, func, priors=None, silent=False, **kwargs):
             if (chol_inv[1] != key_ls):
                 raise ValueError('The keys of inverse covariance matrix are not the same or do not appear in the same order as the x and y values.')
             chol_inv = chol_inv[0]
+            if np.any(np.diag(chol_inv) <= 0) or (not np.all(chol_inv == np.tril(chol_inv))):
+                raise ValueError('The inverse covariance matrix inv_chol_cov_matrix[0] has to be a lower triangular matrix constructed from a Cholesky decomposition.')
         else:
             corr = covariance(y_all, correlation=True, **kwargs)
             inverrdiag = np.diag(1 / np.asarray(dy_f))

--- a/tests/fits_test.py
+++ b/tests/fits_test.py
@@ -223,6 +223,9 @@ def test_inv_cov_matrix_input_least_squares():
             diff_inv_cov_combined_fit.gamma_method()
             assert(diff_inv_cov_combined_fit.is_zero(atol=1e-12))
 
+        with pytest.raises(ValueError):
+            pe.least_squares(x_dict, data_dict, fitf_dict,  correlated_fit = True, inv_chol_cov_matrix = [corr,chol_inv_keys_combined_fit])
+
 def test_least_squares_invalid_inv_cov_matrix_input():
     xvals = []
     yvals = []


### PR DESCRIPTION
This pr introduces two basic checks of the properties of the matrix `inv_chol_cov_matrix[0]` that can be passed by the user when a correlated fit is performed. While we cannot ensure that the matrix is correctly constructed, the check if the matrix is lower triangular should filter out all the cases wher the covariance matrix, the correlation matrix or an inverse of either is passed.
I've added the check for positive entries of the diagonal because this is another feature of the matrix. I don't expect the user to provide a matrix with negative diagonal entries that is lower triangular, but it is another easy check for correctness.