### PR TITLE
[Fix] Fix off-by-one in Covobs pos bounds check

### DIFF
--- a/pyerrors/covobs.py
+++ b/pyerrors/covobs.py
@@ -31,7 +31,7 @@ class Covobs:
                 else:
                     raise ValueError('Have to specify position of cov-element belonging to mean!')
             else:
-                if pos > self.N:
+                if pos >= self.N:
                     raise ValueError(f'pos {pos} too large for covariance matrix with dimension {self.N}x{self.N}!')
             self._grad = np.zeros((self.N, 1))
             self._grad[pos] = 1.

--- a/pyerrors/covobs.py
+++ b/pyerrors/covobs.py
@@ -31,8 +31,8 @@ class Covobs:
                 else:
                     raise ValueError('Have to specify position of cov-element belonging to mean!')
             else:
-                if pos >= self.N:
-                    raise ValueError(f'pos {pos} too large for covariance matrix with dimension {self.N}x{self.N}!')
+                if pos < 0 or pos >= self.N:
+                    raise ValueError(f'pos {pos} not valid for covariance matrix with dimension {self.N}x{self.N}!')
             self._grad = np.zeros((self.N, 1))
             self._grad[pos] = 1.
         else:

--- a/tests/covobs_test.py
+++ b/tests/covobs_test.py
@@ -115,3 +115,9 @@ def test_covobs_pos_too_large():
     cov = [[1, 0], [0, 1]]
     with pytest.raises(ValueError):
         Covobs(1.0, cov, 'test', pos=2)
+
+
+def test_covobs_pos_negative():
+    cov = [[1, 0], [0, 1]]
+    with pytest.raises(ValueError):
+        Covobs(1.0, cov, 'test', pos=-1)

--- a/tests/covobs_test.py
+++ b/tests/covobs_test.py
@@ -1,6 +1,7 @@
 import autograd.numpy as np
 import pyerrors as pe
 import pytest
+from pyerrors.covobs import Covobs
 
 np.random.seed(0)
 
@@ -108,3 +109,9 @@ def test_covobs_exceptions():
         covobs = pe.cov_Obs([1.5, 0.1], [[1., .2,], [.3, .5]] , 'test')
     with pytest.raises(Exception):
         covobs = pe.cov_Obs([1.5, 0.1], [[8, 4,], [4, -2]] , 'test')
+
+
+def test_covobs_pos_too_large():
+    cov = [[1, 0], [0, 1]]
+    with pytest.raises(ValueError):
+        Covobs(1.0, cov, 'test', pos=2)


### PR DESCRIPTION
Follow up to the making exception messages more explicit: This highlighted a small bug that let to a misleading exception message.